### PR TITLE
using gcc 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.8
+      - gcc-4.9
       - clang
 
 branches:


### PR DESCRIPTION
doesn't look much different, but there was one change that caught my attention for x86-64:

> Better inlining of memcpy and memset that is aware of value ranges and produces shorter alignment prologues.