### PR TITLE
Add perf tests 

### DIFF
--- a/perf/chan.c
+++ b/perf/chan.c
@@ -1,0 +1,73 @@
+/*
+
+  Copyright (c) 2015 Martin Sustrik
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+#include "../libdill.h"
+
+static coroutine void worker(int in, int out) {
+    int val;
+    while(1) {
+        chrecv(in, &val, sizeof(val), -1);
+        chsend(out, &val, sizeof(val), -1);
+    }
+}
+
+int main(int argc, char *argv[]) {
+    if(argc != 2) {
+        printf("usage: chan <millions-of-roundtrips>\n");
+        return 1;
+    }
+    long count = atol(argv[1]) * 1000000;
+
+    int out = channel(sizeof(int), 0);
+    int in = channel(sizeof(int), 0);
+
+    int64_t start = now();
+    go(worker(out, in));
+
+    int val = 0;
+    long i;
+    for(i = 0; i != count; ++i) {
+        chsend(out, &val, sizeof(val), -1);
+        chrecv(in, &val, sizeof(val), -1);
+    }
+
+    int64_t stop = now();
+    long duration = (long)(stop - start);
+    long ns = (duration * 1000000) / (count * 2);
+
+    printf("done %ldM roundtrips in %f seconds\n",
+        (long)(count / 1000000), ((float)duration) / 1000);
+    printf("duration of passing a single message: %ld ns\n", ns);
+    printf("message passes per second: %fM\n",
+        (float)(1000000000 / ns) / 1000000);
+
+    return 0;
+}
+

--- a/perf/chr.c
+++ b/perf/chr.c
@@ -1,0 +1,64 @@
+/*
+
+  Copyright (c) 2015 Martin Sustrik
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+#include "../libdill.h"
+
+int main(int argc, char *argv[]) {
+    if(argc != 2) {
+        printf("usage: chr <millions-of-messages>\n");
+        return 1;
+    }
+    long count = atol(argv[1]) * 1000000;
+
+    int ch = channel(sizeof(char), count);
+
+    long i;
+    char val = 0;
+    for(i = 0; i != count; ++i)
+        chsend(ch, &val, sizeof(char), -1);
+
+    int64_t start = now();
+
+    for(i = 0; i != count; ++i)
+        chrecv(ch, &val, sizeof(char), -1);
+
+    int64_t stop = now();
+    long duration = (long)(stop - start);
+    long ns = duration * 1000000 / count;
+
+    printf("received %ldM messages in %f seconds\n",
+        (long)(count / 1000000), ((float)duration) / 1000);
+    printf("duration of receiving a single message: %ld ns\n", ns);
+    printf("message received per second: %fM\n",
+        (float)(1000000000 / ns) / 1000000);
+
+    return 0;
+}
+

--- a/perf/chs.c
+++ b/perf/chs.c
@@ -1,0 +1,61 @@
+/*
+
+  Copyright (c) 2015 Martin Sustrik
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+#include "../libdill.h"
+
+int main(int argc, char *argv[]) {
+    if(argc != 2) {
+        printf("usage: chs <millions-of-messages>\n");
+        return 1;
+    }
+    long count = atol(argv[1]) * 1000000;
+
+    int ch = channel(sizeof(char), count);
+
+    int64_t start = now();
+
+    long i;
+    char val = 0;
+    for(i = 0; i != count; ++i)
+        chsend(ch, &val, sizeof(val), -1);
+
+    int64_t stop = now();
+    long duration = (long)(stop - start);
+    long ns = duration * 1000000 / count;
+
+    printf("sent %ldM messages in %f seconds\n",
+        (long)(count / 1000000), ((float)duration) / 1000);
+    printf("duration of sending a single message: %ld ns\n", ns);
+    printf("message sent per second: %fM\n",
+        (float)(1000000000 / ns) / 1000000);
+
+    return 0;
+}
+

--- a/perf/ctxswitch.c
+++ b/perf/ctxswitch.c
@@ -1,0 +1,65 @@
+/*
+
+  Copyright (c) 2015 Martin Sustrik
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+#include "../libdill.h"
+
+static coroutine void worker(long count) {
+    long i;
+    for(i = 0; i != count; ++i)
+        yield();
+}
+
+int main(int argc, char *argv[]) {
+    if(argc != 2) {
+        printf("usage: ctxswitch <millions-of-context-switches>\n");
+        return 1;
+    }
+    long count = atol(argv[1]) * 1000000 / 2;
+
+    int64_t start = now();
+    go(worker(count));
+
+    long i;
+    for(i = 0; i != count; ++i)
+        yield();
+
+    int64_t stop = now();
+    long duration = (long)(stop - start);
+    long ns = (duration * 1000000) / (count * 2);
+
+    printf("performed %ldM context switches in %f seconds\n",
+        (long)(count * 2 / 1000000), ((float)duration) / 1000);
+    printf("duration of one context switch: %ld ns\n", ns);
+    printf("context switches per second: %fM\n",
+        (float)(1000000000 / ns) / 1000000);
+
+    return 0;
+}
+

--- a/perf/go.c
+++ b/perf/go.c
@@ -1,0 +1,61 @@
+/*
+
+  Copyright (c) 2015 Martin Sustrik
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+#include "../libdill.h"
+
+static coroutine void worker(void) {
+}
+
+int main(int argc, char *argv[]) {
+    if(argc != 2) {
+        printf("usage: go <millions-of-coroutines>\n");
+        return 1;
+    }
+    long count = atol(argv[1]) * 1000000;
+
+    int64_t start = now();
+
+    long i;
+    for(i = 0; i != count; ++i)
+        go(worker());
+
+    int64_t stop = now();
+    long duration = (long)(stop - start);
+    long ns = (duration * 1000000) / count;
+
+    printf("executed %ldM coroutines in %f seconds\n",
+        (long)(count / 1000000), ((float)duration) / 1000);
+    printf("duration of one coroutine creation+termination: %ld ns\n", ns);
+    printf("coroutine creations+terminatios per second: %fM\n",
+        (float)(1000000000 / ns) / 1000000);
+
+    return 0;
+}
+

--- a/perf/whispers.c
+++ b/perf/whispers.c
@@ -1,0 +1,75 @@
+/*
+
+  Copyright (c) 2015 Alex Cornejo
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/time.h>
+
+#include "../libdill.h"
+
+static coroutine void whisper(int left, int right) {
+    int val;
+    chrecv(right, &val, sizeof(val), -1);
+    val++;
+    chsend(left, &val, sizeof(val), -1);
+}
+
+int main(int argc, char *argv[]) {
+    if(argc != 2) {
+        printf("usage: whispers <number-of-whispers>\n");
+        return 1;
+    }
+
+    long count = atol(argv[1]);
+    int64_t start = now();
+
+    int leftmost = channel(sizeof(int), 0);
+    int left = leftmost, right = leftmost;
+    long i;
+    for (i = 0; i < count; ++i) {
+        right = channel(sizeof(int), 0);
+        go(whisper(left, right));
+        left = right;
+    }
+
+    int val = 1;
+    chsend(right, &val, sizeof(val), -1);
+    int res;
+    chrecv(leftmost, &res, sizeof(res), -1);
+    assert(res == count + 1);
+
+    int64_t stop = now();
+    long duration = (long)(stop - start);
+    long ns = (duration * 1000000) / count;
+
+    printf("took %f seconds\n", (float)duration / 1000);
+    printf("performed %ld whispers in %f seconds\n", count, ((float)duration) / 1000);
+    printf("duration of one whisper: %ld ns\n", ns);
+    printf("whispers per second: %fM\n",
+        (float)(1000000000 / ns) / 1000000);
+
+    return 0;
+}


### PR DESCRIPTION
I ported (most of) the perf tests from libmill to libdill, just to get some rough performance status.

A few things:

- I used a deadline of `-1` everywhere. This seems unidiomatic for libdill, but better for performance? 
- No error checking, but this is how the libmill tests were.