### PR TITLE
Clobber all registers in context switching for compiler compatibility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Michael Gehring <mg@ebfe.org>
 Nick Desaulniers <nick@mozilla.com>
 Nir Soffer <nsoffer@redhat.com>
 Paul Banks <banks@banksdesigns.co.uk>
+Tai Chi Minh Ralph Eastwood <tcmreastwood@gmail.com>
 Yue Xu <red_angelx@qq.com>
 Zach Banks <zbanks@mit.edu>
 

--- a/cr.c
+++ b/cr.c
@@ -353,7 +353,7 @@ int dill_wait(void)  {
     }
     /* Store the context of the current coroutine, if any. */
     if(dill_r) {
-        if(sigsetjmp(dill_r->ctx,0)) {
+        if(dill_setjmp(dill_r->ctx)) {
             /* We get here once the coroutine is resumed. */
             dill_slist_init(&dill_r->clauses);
             errno = dill_r->err;
@@ -366,7 +366,7 @@ int dill_wait(void)  {
             ++counter;
             struct dill_slist_item *it = dill_slist_pop(&dill_ready);
             dill_r = dill_cont(it, struct dill_cr, ready);
-            siglongjmp(dill_r->ctx, 1);
+            dill_longjmp(dill_r->ctx);
         }
         /* Otherwise, we are going to wait for sleeping coroutines
            and for external events. */

--- a/libdill.h
+++ b/libdill.h
@@ -104,9 +104,16 @@ DILL_EXPORT int dill_proc_prologue(int *hndl);
 DILL_EXPORT void dill_proc_epilogue(void);
 
 #if defined(__x86_64__)
+#if defined(__AVX__)
+#define DILL_CLOBBER \
+        , "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6", "ymm7",\
+        "ymm8", "ymm9", "ymm10", "ymm11", "ymm12", "ymm13", "ymm14", "ymm15"
+#else
+#define DILL_CLOBBER
+#endif
 #define dill_setjmp(ctx) ({\
     int ret;\
-    asm ("lea     LJMPRET%=(%%rip), %%rcx\n\t"\
+    asm("lea     LJMPRET%=(%%rip), %%rcx\n\t"\
         "xor     %%rax, %%rax\n\t"\
         "mov     %%rbx, (%%rdx)\n\t"\
         "mov     %%rbp, 8(%%rdx)\n\t"\
@@ -120,22 +127,27 @@ DILL_EXPORT void dill_proc_epilogue(void);
         "mov     %%rsi, 72(%%rdx)\n\t"\
         "LJMPRET%=:\n\t"\
         : "=a" (ret)\
-        : "d" (ctx) : "memory");\
+        : "d" (ctx)\
+        : "memory", "rcx", "r8", "r9", "r10", "r11",\
+          "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",\
+          "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15"\
+          DILL_CLOBBER\
+          );\
     ret;\
 })
 #define dill_longjmp(ctx) \
     asm("movq   (%%rax), %%rbx\n\t"\
-	    "movq   8(%%rax), %%rbp\n\t"\
-	    "movq   16(%%rax), %%r12\n\t"\
-	    "movq   24(%%rax), %%rdx\n\t"\
-	    "movq   32(%%rax), %%r13\n\t"\
-	    "movq   40(%%rax), %%r14\n\t"\
-	    "mov    %%rdx, %%rsp\n\t"\
-	    "movq   48(%%rax), %%r15\n\t"\
-	    "movq   56(%%rax), %%rdx\n\t"\
-	    "movq   64(%%rax), %%rdi\n\t"\
-	    "movq   72(%%rax), %%rsi\n\t"\
-	    "jmp    *%%rdx\n\t"\
+        "movq   8(%%rax), %%rbp\n\t"\
+        "movq   16(%%rax), %%r12\n\t"\
+        "movq   24(%%rax), %%rdx\n\t"\
+        "movq   32(%%rax), %%r13\n\t"\
+        "movq   40(%%rax), %%r14\n\t"\
+        "mov    %%rdx, %%rsp\n\t"\
+        "movq   48(%%rax), %%r15\n\t"\
+        "movq   56(%%rax), %%rdx\n\t"\
+        "movq   64(%%rax), %%rdi\n\t"\
+        "movq   72(%%rax), %%rsi\n\t"\
+        "jmp    *%%rdx\n\t"\
         : : "a" (ctx) : "rdx" \
     )
 #else


### PR DESCRIPTION
Re-introduced the register clobbering in the x86-64 implementation of context switching as clang is less conservative than gcc.