### PR TITLE
Assembly support 32-bit context switch and for x86 setting stack pointer

### DIFF
--- a/cr.c
+++ b/cr.c
@@ -76,7 +76,7 @@ struct dill_cr {
        than nothing. */
     int sid;
 #endif
-};
+} __attribute__((aligned(16),packed));
 
 /* Storage for constants used by go() macro. */
 volatile int dill_unoptimisable1 = 1;

--- a/libdill.h
+++ b/libdill.h
@@ -178,7 +178,8 @@ DILL_EXPORT void dill_proc_epilogue(void);
         "jmp    *%%edx\n\t"\
         : : "a" (ctx) : "edx" \
     )
-#define dill_setsp(x) asm volatile("leal -4(%%eax), %%esp"::"eax"(x));
+/* TODO: investigate why clang fails without -16 */
+#define dill_setsp(x) asm volatile("leal -16(%%eax), %%esp"::"eax"(x));
 #else
 #define dill_setjmp(ctx) sigsetjmp(ctx, 0)
 #define dill_longjmp(ctx) siglongjmp(ctx, 1)

--- a/libdill.h
+++ b/libdill.h
@@ -165,8 +165,7 @@ DILL_EXPORT void dill_proc_epilogue(void);
         "jmp    *%%edx\n\t"\
         : : "a" (ctx) : "edx" \
     )
-/* TODO: investigate why clang fails without -16 */
-#define dill_setsp(x) asm volatile("leal -16(%%eax), %%esp"::"eax"(x));
+#define dill_setsp(x) asm volatile("leal -4(%%eax), %%esp"::"eax"(x));
 #else
 #define dill_setjmp(ctx) sigsetjmp(ctx, 0)
 #define dill_longjmp(ctx) siglongjmp(ctx, 1)

--- a/libdill.h
+++ b/libdill.h
@@ -94,7 +94,6 @@ DILL_EXPORT int hclose(int h);
 /******************************************************************************/
 
 #define coroutine __attribute__((noinline))
-#define dill_naked __attribute__((optimize("omit-frame-pointer",3)))
 
 DILL_EXPORT extern volatile int dill_unoptimisable1;
 DILL_EXPORT extern volatile void *dill_unoptimisable2;

--- a/libdill.h
+++ b/libdill.h
@@ -105,13 +105,6 @@ DILL_EXPORT int dill_proc_prologue(int *hndl);
 DILL_EXPORT void dill_proc_epilogue(void);
 
 #if defined(__x86_64__)
-#if defined(__AVX__)
-#define DILL_CLOBBER \
-        , "ymm0", "ymm1", "ymm2", "ymm3", "ymm4", "ymm5", "ymm6", "ymm7",\
-        "ymm8", "ymm9", "ymm10", "ymm11", "ymm12", "ymm13", "ymm14", "ymm15"
-#else
-#define DILL_CLOBBER
-#endif
 #define dill_setjmp(ctx) ({\
     int ret;\
     asm("lea     LJMPRET%=(%%rip), %%rcx\n\t"\
@@ -129,11 +122,7 @@ DILL_EXPORT void dill_proc_epilogue(void);
         "LJMPRET%=:\n\t"\
         : "=a" (ret)\
         : "d" (ctx)\
-        : "memory", "rcx", "r8", "r9", "r10", "r11",\
-          "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7",\
-          "xmm8", "xmm9", "xmm10", "xmm11", "xmm12", "xmm13", "xmm14", "xmm15"\
-          DILL_CLOBBER\
-          );\
+        : "memory", "rcx", "r8", "r9", "r10", "r11");\
     ret;\
 })
 #define dill_longjmp(ctx) \
@@ -164,8 +153,7 @@ DILL_EXPORT void dill_proc_epilogue(void);
         "movl   %%esp, 20(%%edx)\n\t"\
         "xorl   %%eax, %%eax\n\t"\
         "LJMPRET%=:\n\t"\
-        : "=a" (ret) : "d" (ctx) : "memory", "ecx",\
-        "xmm0", "xmm1", "xmm2", "xmm3", "xmm4", "xmm5", "xmm6", "xmm7");\
+        : "=a" (ret) : "d" (ctx) : "memory");\
     ret;\
 })
 #define dill_longjmp(ctx) \


### PR DESCRIPTION
Some cleanups; after reading the ABI, it appears that any function call boundary will clear xmm registers.  After examining the go macro, dill_prologue and fn are both "real" calls, and thus the compiler will already mark these registers as dirty.

There is a new 32-bit implementation of context switching; currently there's some issue with clang (at least on my system).  Clang requires a larger offset within the coroutine stack.  Further investigation is required.

The new feature is dill_setsp which directly sets the stack pointer within the `go` macro.  This bypasses the stack protection mechanism provided by -fstack-protector for coroutines only (but still allowing them for non-coroutines).  This is important for newer versions of GCC.  Stack protection for the coroutine stacks is already provided in libdill using `mprotect`.