### PR TITLE
Compatible setjmp/longjmp

### DIFF
--- a/libdill.h
+++ b/libdill.h
@@ -130,19 +130,19 @@ DILL_EXPORT void dill_proc_epilogue(void);
         "LJMPRET%=:\n\t"\
         : "=a" (ret)\
         : "d" (ctx)\
-        : "memory", "rcx", "r8", "r9", "r10", "r11", "cc");\
+        : "memory", "rcx", "rsi", "rdi", "r8", "r9", "r10", "r11", "cc");\
     ret;\
 })
 #define dill_longjmp(ctx) \
-    asm("movq   56(%%rax), %%rdx\n\t"\
-        "movq   48(%%rax), %%rsp\n\t"\
-        "movq   40(%%rax), %%r15\n\t"\
-        "movq   32(%%rax), %%r14\n\t"\
-        "movq   24(%%rax), %%r13\n\t"\
-        "movq   16(%%rax), %%r12\n\t"\
-        "movq   8(%%rax), %%rbp\n\t"\
-        "movq   (%%rax), %%rbx\n\t"\
-        ".cfi_def_cfa %%rax, 0 \n\t"\
+    asm("movq   56(%%rdx), %%rcx\n\t"\
+        "movq   48(%%rdx), %%rsp\n\t"\
+        "movq   40(%%rdx), %%r15\n\t"\
+        "movq   32(%%rdx), %%r14\n\t"\
+        "movq   24(%%rdx), %%r13\n\t"\
+        "movq   16(%%rdx), %%r12\n\t"\
+        "movq   8(%%rdx), %%rbp\n\t"\
+        "movq   (%%rdx), %%rbx\n\t"\
+        ".cfi_def_cfa %%rdx, 0 \n\t"\
         ".cfi_offset %%rbx, 0 \n\t"\
         ".cfi_offset %%rbp, 8 \n\t"\
         ".cfi_offset %%r12, 16 \n\t"\
@@ -150,9 +150,9 @@ DILL_EXPORT void dill_proc_epilogue(void);
         ".cfi_offset %%r14, 32 \n\t"\
         ".cfi_offset %%r15, 40 \n\t"\
         ".cfi_offset %%rsp, 48 \n\t"\
-        ".cfi_offset %%rcx, 56 \n\t"\
-        "jmp    *%%rdx\n\t"\
-        : : "a" (ctx))
+        ".cfi_offset %%rip, 56 \n\t"\
+        "jmp    *%%rcx\n\t"\
+        : : "d" (ctx), "a" (1))
 #define DILL_SETSP(x) \
     asm(""::"r"(alloca(sizeof(size_t))));\
     asm volatile("leaq (%%rax), %%rsp"::"rax"(x));
@@ -160,34 +160,35 @@ DILL_EXPORT void dill_proc_epilogue(void);
 /* Stack switching on X86. */
 #elif defined(__i386__) && !defined DILL_ARCH_FALLBACK
 #define dill_setjmp(ctx) ({\
-    asm("movl   $LJMPRET%=, %%eax\n\t"\
+    int ret;\
+    asm("movl   $LJMPRET%=, %%ecx\n\t"\
         "movl   %%ebx, (%%edx)\n\t"\
         "movl   %%esi, 4(%%edx)\n\t"\
         "movl   %%edi, 8(%%edx)\n\t"\
         "movl   %%ebp, 12(%%edx)\n\t"\
-        "movl   %%eax, 16(%%edx)\n\t"\
-        "movl   %%esp, 20(%%edx)\n\t"\
+        "movl   %%esp, 16(%%edx)\n\t"\
+        "movl   %%ecx, 20(%%edx)\n\t"\
         "xorl   %%eax, %%eax\n\t"\
         "LJMPRET%=:\n\t"\
         : "=a" (ret) : "d" (ctx) : "memory");\
     ret;\
 })
 #define dill_longjmp(ctx) \
-    asm("movl   (%%eax), %%ebx\n\t"\
-        "movl   4(%%eax), %%esi\n\t"\
-        "movl   8(%%eax), %%edi\n\t"\
-        "movl   12(%%eax), %%ebp\n\t"\
-        "movl   16(%%eax), %%edx\n\t"\
-        "movl   20(%%eax), %%esp\n\t"\
-        ".cfi_def_cfa %%eax, 0 \n\t"\
+    asm("movl   (%%edx), %%ebx\n\t"\
+        "movl   4(%%edx), %%esi\n\t"\
+        "movl   8(%%edx), %%edi\n\t"\
+        "movl   12(%%edx), %%ebp\n\t"\
+        "movl   16(%%edx), %%esp\n\t"\
+        "movl   20(%%edx), %%ecx\n\t"\
+        ".cfi_def_cfa %%edx, 0 \n\t"\
         ".cfi_offset %%ebx, 0 \n\t"\
         ".cfi_offset %%esi, 4 \n\t"\
         ".cfi_offset %%edi, 8 \n\t"\
         ".cfi_offset %%ebp, 12 \n\t"\
-        ".cfi_offset %%edx, 16 \n\t"\
-        ".cfi_offset %%esp, 20 \n\t"\
-        "jmp    *%%edx\n\t"\
-        : : "a" (ctx))
+        ".cfi_offset %%esp, 16 \n\t"\
+        ".cfi_offset %%eip, 20 \n\t"\
+        "jmp    *%%ecx\n\t"\
+        : : "d" (ctx), "a" (1))
 #define DILL_SETSP(x) \
     asm(""::"r"(alloca(sizeof(size_t))));\
     asm volatile("leal (%%eax), %%esp"::"eax"(x));

--- a/libdill.h
+++ b/libdill.h
@@ -107,6 +107,10 @@ DILL_EXPORT void dill_proc_epilogue(void);
 /* In the following macros alloca(sizeof(size_t)) is used because clang
    doesn't support alloca with size zero. */
 
+/* This assembly setjmp/longjmp mechanism is in the same order as glibc and
+   musl but glibc implements pointer mangling, which is hard to support.
+   This should be binary-compatible with musl though. */
+
 /* Stack-switching on X86-64. */
 #if defined(__x86_64__) && !defined DILL_ARCH_FALLBACK
 #define dill_setjmp(ctx) ({\


### PR DESCRIPTION
The series of patches brings compatibility between the system setjmp/longjmp implementation and the one used by libdill in x86-64 and i386 systems.

- This works with musl which does not implement pointer mangling.
- Glibc has some complex pointer mangling for security, and I do not know how to replicate it right now, but I might be able to do in the future if I investigate a bit further - but this would be relevant pre-patch work because the registers are still stored in the same order.
- Previous implementation was unnecessarily preserving rsi/rdi on x86-64, so this is faster.
- Dropped sigsetjmp and siglongjmp because we do not use them.