### PR TITLE
Experimental Cygwin Support

### DIFF
--- a/cr.c
+++ b/cr.c
@@ -361,6 +361,12 @@ int dill_prologue(jmp_buf **ctx, void **ptr, size_t len,
     dill_resume(dill_r, 0, 0);
     /* Mark the new coroutine as running. */
     *ptr = dill_r = cr;
+#if defined __CYGWIN__
+    /* TODO: On cygwin, the compiler assumes there's some writeable stack below
+       the stack pointer.  This line implements a red zone.
+       I'm not entirely sure this is correct, but it appears to work. */
+    *ptr -= 128;
+#endif
     return hndl;
 }
 

--- a/cr.c
+++ b/cr.c
@@ -72,7 +72,7 @@ struct dill_cr {
     int err;
     /* When coroutine is suspended 'ctx' holds the context
        (registers and such). */
-    sigjmp_buf ctx;
+    jmp_buf ctx;
     /* If coroutine is blocked, here's the list of clauses it waits for. */
     struct dill_slist clauses;
     /* Coroutine-local storage. */
@@ -278,7 +278,7 @@ static void dill_cr_close(struct hvfs *vfs);
 static void dill_cancel(struct dill_cr *cr, int err);
 
 /* The intial part of go(). Allocates a new stack and handle. */
-int dill_prologue(sigjmp_buf **ctx, void **ptr, size_t len,
+int dill_prologue(jmp_buf **ctx, void **ptr, size_t len,
       const char *file, int line) {
     /* Return ECANCELED if shutting down. */
     int rc = dill_canblock();

--- a/libdill.h
+++ b/libdill.h
@@ -158,13 +158,13 @@ DILL_EXPORT void dill_proc_epilogue(void);
 /* Stack switching on X86. */
 #elif defined(__i386__) && !defined DILL_ARCH_FALLBACK
 #define dill_setjmp(ctx) ({\
-    asm("movl   $LJMPRET%=, %%eax\n\t"\
+    asm("movl   $LJMPRET%=, %%ecx\n\t"\
         "movl   %%ebx, (%%edx)\n\t"\
         "movl   %%esi, 4(%%edx)\n\t"\
         "movl   %%edi, 8(%%edx)\n\t"\
         "movl   %%ebp, 12(%%edx)\n\t"\
-        "movl   %%eax, 16(%%edx)\n\t"\
-        "movl   %%esp, 20(%%edx)\n\t"\
+        "movl   %%esp, 16(%%edx)\n\t"\
+        "movl   %%ecx, 20(%%edx)\n\t"\
         "xorl   %%eax, %%eax\n\t"\
         "LJMPRET%=:\n\t"\
         : "=a" (ret) : "d" (ctx) : "memory");\
@@ -182,8 +182,8 @@ DILL_EXPORT void dill_proc_epilogue(void);
         ".cfi_offset %%esi, 4 \n\t"\
         ".cfi_offset %%edi, 8 \n\t"\
         ".cfi_offset %%ebp, 12 \n\t"\
-        ".cfi_offset %%eip, 16 \n\t"\
-        ".cfi_offset %%esp, 20 \n\t"\
+        ".cfi_offset %%esp, 16 \n\t"\
+        ".cfi_offset %%eip, 20 \n\t"\
         "jmp    *%%ecx\n\t"\
         : : "d" (ctx), "a" (1))
 #define DILL_SETSP(x) \

--- a/libdill.h
+++ b/libdill.h
@@ -128,19 +128,19 @@ DILL_EXPORT void dill_proc_epilogue(void);
         "LJMPRET%=:\n\t"\
         : "=a" (ret)\
         : "d" (ctx)\
-        : "memory", "rcx", "r8", "r9", "r10", "r11", "cc");\
+        : "memory", "rcx", "rsi", "rdi", "r8", "r9", "r10", "r11", "cc");\
     ret;\
 })
 #define dill_longjmp(ctx) \
-    asm("movq   56(%%rax), %%rdx\n\t"\
-        "movq   48(%%rax), %%rsp\n\t"\
-        "movq   40(%%rax), %%r15\n\t"\
-        "movq   32(%%rax), %%r14\n\t"\
-        "movq   24(%%rax), %%r13\n\t"\
-        "movq   16(%%rax), %%r12\n\t"\
-        "movq   8(%%rax), %%rbp\n\t"\
-        "movq   (%%rax), %%rbx\n\t"\
-        ".cfi_def_cfa %%rax, 0 \n\t"\
+    asm("movq   56(%%rdx), %%rcx\n\t"\
+        "movq   48(%%rdx), %%rsp\n\t"\
+        "movq   40(%%rdx), %%r15\n\t"\
+        "movq   32(%%rdx), %%r14\n\t"\
+        "movq   24(%%rdx), %%r13\n\t"\
+        "movq   16(%%rdx), %%r12\n\t"\
+        "movq   8(%%rdx), %%rbp\n\t"\
+        "movq   (%%rdx), %%rbx\n\t"\
+        ".cfi_def_cfa %%rdx, 0 \n\t"\
         ".cfi_offset %%rbx, 0 \n\t"\
         ".cfi_offset %%rbp, 8 \n\t"\
         ".cfi_offset %%r12, 16 \n\t"\
@@ -149,8 +149,8 @@ DILL_EXPORT void dill_proc_epilogue(void);
         ".cfi_offset %%r15, 40 \n\t"\
         ".cfi_offset %%rsp, 48 \n\t"\
         ".cfi_offset %%rcx, 56 \n\t"\
-        "jmp    *%%rdx\n\t"\
-        : : "a" (ctx))
+        "jmp    *%%rcx\n\t"\
+        : : "d" (ctx), "a" (1))
 #define DILL_SETSP(x) \
     asm(""::"r"(alloca(sizeof(size_t))));\
     asm volatile("leaq (%%rax), %%rsp"::"rax"(x));
@@ -171,21 +171,21 @@ DILL_EXPORT void dill_proc_epilogue(void);
     ret;\
 })
 #define dill_longjmp(ctx) \
-    asm("movl   (%%eax), %%ebx\n\t"\
-        "movl   4(%%eax), %%esi\n\t"\
-        "movl   8(%%eax), %%edi\n\t"\
-        "movl   12(%%eax), %%ebp\n\t"\
-        "movl   16(%%eax), %%edx\n\t"\
-        "movl   20(%%eax), %%esp\n\t"\
-        ".cfi_def_cfa %%eax, 0 \n\t"\
+    asm("movl   (%%edx), %%ebx\n\t"\
+        "movl   4(%%edx), %%esi\n\t"\
+        "movl   8(%%edx), %%edi\n\t"\
+        "movl   12(%%edx), %%ebp\n\t"\
+        "movl   16(%%edx), %%ecx\n\t"\
+        "movl   20(%%edx), %%esp\n\t"\
+        ".cfi_def_cfa %%edx, 0 \n\t"\
         ".cfi_offset %%ebx, 0 \n\t"\
         ".cfi_offset %%esi, 4 \n\t"\
         ".cfi_offset %%edi, 8 \n\t"\
         ".cfi_offset %%ebp, 12 \n\t"\
         ".cfi_offset %%edx, 16 \n\t"\
         ".cfi_offset %%esp, 20 \n\t"\
-        "jmp    *%%edx\n\t"\
-        : : "a" (ctx))
+        "jmp    *%%ecx\n\t"\
+        : : "d" (ctx), "a" (1))
 #define DILL_SETSP(x) \
     asm(""::"r"(alloca(sizeof(size_t))));\
     asm volatile("leal (%%eax), %%esp"::"eax"(x));

--- a/libdill.h
+++ b/libdill.h
@@ -148,7 +148,7 @@ DILL_EXPORT void dill_proc_epilogue(void);
         ".cfi_offset %%r14, 32 \n\t"\
         ".cfi_offset %%r15, 40 \n\t"\
         ".cfi_offset %%rsp, 48 \n\t"\
-        ".cfi_offset %%rcx, 56 \n\t"\
+        ".cfi_offset %%rip, 56 \n\t"\
         "jmp    *%%rcx\n\t"\
         : : "d" (ctx), "a" (1))
 #define DILL_SETSP(x) \
@@ -182,7 +182,7 @@ DILL_EXPORT void dill_proc_epilogue(void);
         ".cfi_offset %%esi, 4 \n\t"\
         ".cfi_offset %%edi, 8 \n\t"\
         ".cfi_offset %%ebp, 12 \n\t"\
-        ".cfi_offset %%edx, 16 \n\t"\
+        ".cfi_offset %%eip, 16 \n\t"\
         ".cfi_offset %%esp, 20 \n\t"\
         "jmp    *%%ecx\n\t"\
         : : "d" (ctx), "a" (1))

--- a/libdill.h
+++ b/libdill.h
@@ -158,6 +158,7 @@ DILL_EXPORT void dill_proc_epilogue(void);
 /* Stack switching on X86. */
 #elif defined(__i386__) && !defined DILL_ARCH_FALLBACK
 #define dill_setjmp(ctx) ({\
+    int ret;
     asm("movl   $LJMPRET%=, %%ecx\n\t"\
         "movl   %%ebx, (%%edx)\n\t"\
         "movl   %%esi, 4(%%edx)\n\t"\
@@ -175,8 +176,8 @@ DILL_EXPORT void dill_proc_epilogue(void);
         "movl   4(%%edx), %%esi\n\t"\
         "movl   8(%%edx), %%edi\n\t"\
         "movl   12(%%edx), %%ebp\n\t"\
-        "movl   16(%%edx), %%ecx\n\t"\
-        "movl   20(%%edx), %%esp\n\t"\
+        "movl   16(%%edx), %%esp\n\t"\
+        "movl   20(%%edx), %%ecx\n\t"\
         ".cfi_def_cfa %%edx, 0 \n\t"\
         ".cfi_offset %%ebx, 0 \n\t"\
         ".cfi_offset %%esi, 4 \n\t"\

--- a/libdill.h
+++ b/libdill.h
@@ -107,6 +107,10 @@ DILL_EXPORT void dill_proc_epilogue(void);
 /* In the following macros alloca(sizeof(size_t)) is used because clang
    doesn't support alloca with size zero. */
 
+/* This assembly setjmp/longjmp mechanism is in the same order as glibc and
+   musl but glibc implements pointer mangling, which is hard to support.
+   This should be binary-compatible with musl though. */
+
 /* Stack-switching on X86-64. */
 #if defined(__x86_64__) && !defined DILL_ARCH_FALLBACK
 #define dill_setjmp(ctx) ({\

--- a/libdill.h
+++ b/libdill.h
@@ -116,30 +116,37 @@ DILL_EXPORT void dill_proc_epilogue(void);
         "mov     %%rbx, (%%rdx)\n\t"\
         "mov     %%rbp, 8(%%rdx)\n\t"\
         "mov     %%r12, 16(%%rdx)\n\t"\
-        "mov     %%rsp, 24(%%rdx)\n\t"\
-        "mov     %%r13, 32(%%rdx)\n\t"\
-        "mov     %%r14, 40(%%rdx)\n\t"\
-        "mov     %%r15, 48(%%rdx)\n\t"\
+        "mov     %%r13, 24(%%rdx)\n\t"\
+        "mov     %%r14, 32(%%rdx)\n\t"\
+        "mov     %%r15, 40(%%rdx)\n\t"\
+        "mov     %%rsp, 48(%%rdx)\n\t"\
         "mov     %%rcx, 56(%%rdx)\n\t"\
         "LJMPRET%=:\n\t"\
         : "=a" (ret)\
         : "d" (ctx)\
-        : "memory", "rcx", "r8", "r9", "r10", "r11");\
+        : "memory", "rcx", "r8", "r9", "r10", "r11", "cc");\
     ret;\
 })
 #define dill_longjmp(ctx) \
-    asm("movq   (%%rax), %%rbx\n\t"\
-        "movq   8(%%rax), %%rbp\n\t"\
+    asm("movq   56(%%rax), %%rdx\n\t"\
+        "movq   48(%%rax), %%rsp\n\t"\
+        "movq   40(%%rax), %%r15\n\t"\
+        "movq   32(%%rax), %%r14\n\t"\
+        "movq   24(%%rax), %%r13\n\t"\
         "movq   16(%%rax), %%r12\n\t"\
-        "movq   24(%%rax), %%rdx\n\t"\
-        "movq   32(%%rax), %%r13\n\t"\
-        "movq   40(%%rax), %%r14\n\t"\
-        "mov    %%rdx, %%rsp\n\t"\
-        "movq   48(%%rax), %%r15\n\t"\
-        "movq   56(%%rax), %%rdx\n\t"\
+        "movq   8(%%rax), %%rbp\n\t"\
+        "movq   (%%rax), %%rbx\n\t"\
+        ".cfi_def_cfa %%rax, 0 \n\t"\
+        ".cfi_offset %%rbx, 0 \n\t"\
+        ".cfi_offset %%rbp, 8 \n\t"\
+        ".cfi_offset %%r12, 16 \n\t"\
+        ".cfi_offset %%r13, 24 \n\t"\
+        ".cfi_offset %%r14, 32 \n\t"\
+        ".cfi_offset %%r15, 40 \n\t"\
+        ".cfi_offset %%rsp, 48 \n\t"\
+        ".cfi_offset %%rcx, 56 \n\t"\
         "jmp    *%%rdx\n\t"\
-        : : "a" (ctx) : "rdx" \
-    )
+        : : "a" (ctx))
 #define DILL_SETSP(x) \
     asm(""::"r"(alloca(sizeof(size_t))));\
     asm volatile("leaq (%%rax), %%rsp"::"rax"(x));
@@ -147,13 +154,12 @@ DILL_EXPORT void dill_proc_epilogue(void);
 /* Stack switching on X86. */
 #elif defined(__i386__) && !defined DILL_ARCH_FALLBACK
 #define dill_setjmp(ctx) ({\
-    int ret;\
     asm("movl   $LJMPRET%=, %%eax\n\t"\
-        "movl   %%eax, (%%edx)\n\t"\
-        "movl   %%ebx, 4(%%edx)\n\t"\
-        "movl   %%esi, 8(%%edx)\n\t"\
-        "movl   %%edi, 12(%%edx)\n\t"\
-        "movl   %%ebp, 16(%%edx)\n\t"\
+        "movl   %%ebx, (%%edx)\n\t"\
+        "movl   %%esi, 4(%%edx)\n\t"\
+        "movl   %%edi, 8(%%edx)\n\t"\
+        "movl   %%ebp, 12(%%edx)\n\t"\
+        "movl   %%eax, 16(%%edx)\n\t"\
         "movl   %%esp, 20(%%edx)\n\t"\
         "xorl   %%eax, %%eax\n\t"\
         "LJMPRET%=:\n\t"\
@@ -161,15 +167,21 @@ DILL_EXPORT void dill_proc_epilogue(void);
     ret;\
 })
 #define dill_longjmp(ctx) \
-    asm("movl   (%%eax), %%edx\n\t"\
-        "movl   4(%%eax), %%ebx\n\t"\
-        "movl   8(%%eax), %%esi\n\t"\
-        "movl   12(%%eax), %%edi\n\t"\
-        "movl   16(%%eax), %%ebp\n\t"\
+    asm("movl   (%%eax), %%ebx\n\t"\
+        "movl   4(%%eax), %%esi\n\t"\
+        "movl   8(%%eax), %%edi\n\t"\
+        "movl   12(%%eax), %%ebp\n\t"\
+        "movl   16(%%eax), %%edx\n\t"\
         "movl   20(%%eax), %%esp\n\t"\
+        ".cfi_def_cfa %%eax, 0 \n\t"\
+        ".cfi_offset %%ebx, 0 \n\t"\
+        ".cfi_offset %%esi, 4 \n\t"\
+        ".cfi_offset %%edi, 8 \n\t"\
+        ".cfi_offset %%ebp, 12 \n\t"\
+        ".cfi_offset %%edx, 16 \n\t"\
+        ".cfi_offset %%esp, 20 \n\t"\
         "jmp    *%%edx\n\t"\
-        : : "a" (ctx) : "edx" \
-    )
+        : : "a" (ctx))
 #define DILL_SETSP(x) \
     asm(""::"r"(alloca(sizeof(size_t))));\
     asm volatile("leal (%%eax), %%esp"::"eax"(x));

--- a/tests/fd.c
+++ b/tests/fd.c
@@ -49,6 +49,11 @@ coroutine void trigger(int fd, int64_t deadline) {
 int main() {
     int rc;
 
+    /* Cygwin does not support AF_UNIX properly */
+#ifdef __CYGWIN__
+    return -1;
+#endif
+
     /* Check invalid fd. */
     rc = fdin(33, -1);
     assert(rc == -1 && errno == EBADF);


### PR DESCRIPTION
All the tests pass on cygwin apart from any that use UNIX sockets.  UNIX socket emulation on cygwin does not seem to be correct.

I compiled dsock against it, and with a compatibility implementation of `recvmsg`, all the tests pass in dsock as well apart from UNIX sockets - so TCP/UDP seems fine.