### PR TITLE
Optimise the single-clause chsend and chrecv

### DIFF
--- a/chan.c
+++ b/chan.c
@@ -137,17 +137,105 @@ static void dill_chan_close(struct hvfs *vfs) {
 /*  Sending and receiving.                                                    */
 /******************************************************************************/
 
+#define CLAUSE_INIT(cl, o, h, v, l)\
+    do {\
+        cl.op = (o);\
+        cl.ch = (h);\
+        cl.val = (void*)(v);\
+        cl.len = (l);\
+    } while(0)
+
 int chsend(int h, const void *val, size_t len, int64_t deadline) {
-    struct chclause cl = {CHSEND, h, (void*)val, len};
-    int rc = choose(&cl, 1, deadline);
-    if(dill_slow(rc < 0 || errno != 0)) return -1;
+    /* Initialise the single clause. */
+    struct chclause cl;
+    CLAUSE_INIT(cl, CHSEND, h, (void*)val, len);
+    int rc = dill_canblock();
+    if(dill_slow(rc < 0)) return -1;
+    /* First pass through the clauses. Find out which are immediately ready. */
+    struct dill_chan *ch = hquery(h, dill_chan_type);
+    if(dill_slow(!ch)) return -1;
+    if(dill_slow(len != ch->sz)) return -1;
+    if(ch->items < ch->bufsz || !dill_list_empty(&ch->in) || ch->done) {
+        if(dill_slow(ch->done)) {errno = EPIPE; return -1;}
+        if(!dill_list_empty(&ch->in)) {
+            /* Copy the message directly to the waiting receiver. */
+            struct dill_chcl *chcl = dill_cont(dill_list_begin(&ch->in),
+                struct dill_chcl, cl.epitem);
+            memcpy(chcl->val, cl.val, len);
+            dill_trigger(&chcl->cl, 0);
+            return 0;
+        }
+        dill_assert(ch->items < ch->bufsz);
+        /* Write the item to the buffer. */
+        size_t pos = (ch->first + ch->items) % ch->bufsz;
+        memcpy(((char*)(ch + 1)) + (pos * len), cl.val, len);
+        ++ch->items;
+        return 0;
+
+    }
+    /* There are no clauses available immediately. */
+    if(dill_slow(deadline == 0)) {errno = ETIMEDOUT; return -1;}
+    /* Let's wait. */
+    struct dill_chcl *chcl = (struct dill_chcl*)&cl.reserved;
+    chcl->val = cl.val;
+    dill_waitfor(&chcl->cl, 0, &ch->out, NULL);
+    struct dill_tmcl tmcl;
+    dill_timer(&tmcl, 1, deadline);
+    int id = dill_wait();
+    if(dill_slow(id < 0)) return -1;
+    if(dill_slow(id == 1)) {errno = ETIMEDOUT; return -1;}
+    if(dill_slow(errno != 0)) return -1;
     return 0;
 }
 
 int chrecv(int h, void *val, size_t len, int64_t deadline) {
-    struct chclause cl = {CHRECV, h, val, len};
-    int rc = choose(&cl, 1, deadline);
-    if(dill_slow(rc < 0 || errno != 0)) return -1;
+    /* Initialise the single clause. */
+    struct chclause cl;
+    CLAUSE_INIT(cl, CHRECV, h, (void*)val, len);
+    int rc = dill_canblock();
+    if(dill_slow(rc < 0)) return -1;
+    /* First pass through the clauses. Find out which are immediately ready. */
+    struct dill_chan *ch = hquery(h, dill_chan_type);
+    if(dill_slow(!ch)) return -1;
+    if(dill_slow(len != ch->sz)) return -1;
+    if(ch->items || !dill_list_empty(&ch->out) || ch->done) {
+        if(dill_slow(ch->done && !ch->items)) {errno = EPIPE; return -1;}
+        if(!ch->items) {
+            /* Unbuffered channel. But there's a sender waiting to send.
+               Copy the message directly from a waiting sender. */
+            struct dill_chcl *chcl = dill_cont(dill_list_begin(&ch->out),
+                struct dill_chcl, cl.epitem);
+            memcpy(cl.val, chcl->val, len);
+            dill_trigger(&chcl->cl, 0);
+            return 0;
+        }
+        /* Read an item from the buffer. */
+        memcpy(cl.val, ((char*)(ch + 1)) + (ch->first * len), len);
+        ch->first = (ch->first + 1) % ch->bufsz;
+        --ch->items;
+        /* If there was a waiting sender, unblock it. */
+        if(!dill_list_empty(&ch->out)) {
+            struct dill_chcl *chcl = dill_cont(dill_list_begin(&ch->out),
+                struct dill_chcl, cl.epitem);
+            size_t pos = (ch->first + ch->items) % ch->bufsz;
+            memcpy(((char*)(ch + 1)) + (pos * len) , chcl->val, len);
+            ++ch->items;
+            dill_trigger(&chcl->cl, 0);
+        }
+        return 0;
+    }
+    /* There are no clauses available immediately. */
+    if(dill_slow(deadline == 0)) {errno = ETIMEDOUT; return -1;}
+    /* Let's wait. */
+    struct dill_chcl *chcl = (struct dill_chcl*)&cl.reserved;
+    chcl->val = cl.val;
+    dill_waitfor(&chcl->cl, 0, &ch->in, NULL);
+    struct dill_tmcl tmcl;
+    dill_timer(&tmcl, 1, deadline);
+    int id = dill_wait();
+    if(dill_slow(id < 0)) return -1;
+    if(dill_slow(id == 1)) {errno = ETIMEDOUT; return -1;}
+    if(dill_slow(errno != 0)) return -1;
     return 0;
 }
 

--- a/handle.c
+++ b/handle.c
@@ -122,7 +122,7 @@ void *hquery(int h, const void *type) {
     else {
         void *ptr = hndl->vfs->query(hndl->vfs, type);
         if(dill_slow(!ptr)) return NULL;
-        /* Update cache */
+        /* Update cache. */
         hndl->type = type;
         hndl->ptr = ptr;
         return ptr;


### PR DESCRIPTION
I've significantly sped up the `chsend` and `chrecv` implementations. I believe this fits in the philosophy of avoiding `choose` , for reference: [Select Statement Considered Harmful](http://250bpm.com/blog:72).

- `hquery` gets called thrice per clause in `choose`, I've implemented last-call caching in `hquery`.
- `chsend` and `chrecv` only need to call `hquery` once
- The initialisation of the clause structure fills `reserved` with zeroes causing an expensive `rep stos` on x86 architectures. Only filling in the necessary elements makes this much faster.
- `chsend` and `chrecv` can avoid setting/checking `errno` until there really is an error; setting `errno` is typically expensive.

On a i7 4770k (GCC 4.9.4), previously:
```bash
$ ./perf/chan 10
done 10M roundtrips in 1.666000 seconds
duration of passing a single message: 83 ns
message passes per second: 12.048192M
```

Afterwards:
```bash
$ ./perf/chan 10
done 10M roundtrips in 0.815000 seconds
duration of passing a single message: 40 ns
message passes per second: 25.000000M
```

Statically compiled with heavier optimisations in one line:
```C
$ gcc -march=native -O3 -flto -fvisibility=hidden *.c perf/chan.c
$ ./a.out 10
done 10M roundtrips in 0.538000 seconds
duration of passing a single message: 26 ns
message passes per second: 38.461536M
```