### PR TITLE
Add 16-byte alignment of client stack and comment

### DIFF
--- a/cr.c
+++ b/cr.c
@@ -101,7 +101,10 @@ struct dill_cr {
     struct dill_census_item *census;
     size_t stacksz;
 #endif
-};
+/* Clang assumes that the client stack is aligned to 16-bytes on x86-64
+   architectures; to achieve this we align this structure (with the added
+   benefit of a minor optimisation). */
+} __attribute__((aligned(16)));
 
 /* Storage for constant used by go() macro. */
 volatile void *dill_unoptimisable = NULL;

--- a/slist.h
+++ b/slist.h
@@ -28,9 +28,6 @@
 #include <stddef.h>
 #include "utils.h"
 
-/* After removing item from a list, next points here. */
-extern struct dill_slist_item dill_slist_item_none;
-
 /* Singly-linked list. Having both push and push_back functions means that
    it can be used both as a queue and as a stack. */
 
@@ -43,6 +40,7 @@ struct dill_slist {
     struct dill_slist_item *last;
 };
 
+/* After removing item from a list, next points here. */
 extern struct dill_slist_item dill_slist_item_none;
 
 #define DILL_SLIST_ITEM_INITIALISER {&dill_slist_item_none}


### PR DESCRIPTION
- Minor cosmetic fix and re-add the alignment of the `struct cr`.
- Perhaps we should consider doing a per-platform check whether the stack needs to be aligned or not.  The bug only happens with `clang` because `clang` strictly follows the ABI guidelines and does not consider custom stacks.  Some versions of GCC, I believe, did also do the same thing at one point, but it introduced too many bugs so they reverted the behaviour to not assume that the stack of a function was aligned.
- Other architectures may vary, so aligning the stack is a safe choice, but may not be a necessary choice.
- It may be desired to be disabled on embedded systems where every byte counts, so maybe `#if defined (__x86_64__) || defined(__i386__)` might be a good solution.