### PR TITLE
Use portable version of make suffixes

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -40,10 +40,12 @@ man3_MANS = \
     now.3 \
     yield.3
 
+SUFFIXES = .md .3
+
 man-local: $(man3_MANS)
 
 # Compile the man page document
-%.3: %.md
+.md.3:
 	$(AM_V_GEN) @PANDOC@ -s -t man $< -o $@ \
 		-M author="Martin Sustrik" \
 		-M header="libdill Library Functions" \


### PR DESCRIPTION
`%.3: %.md` accessible only for GNU make. This is the only GNU-specific thing which does not allow to use BSD make, everything else handled by automake. Portable `.md.3` is enough in this case.