### PR TITLE
Use __FreeBSD__ to detect BSD

### DIFF
--- a/kqueue.c.inc
+++ b/kqueue.c.inc
@@ -1,3 +1,4 @@
+/* -*- mode: c; -*- */
 /*
 
   Copyright (c) 2016 Martin Sustrik

--- a/kqueue.h.inc
+++ b/kqueue.h.inc
@@ -1,3 +1,4 @@
+/* -*- mode: c; -*- */
 /*
 
   Copyright (c) 2016 Martin Sustrik

--- a/pollset.c
+++ b/pollset.c
@@ -34,7 +34,7 @@
 /* Defaults. */
 #elif defined __linux__ && !defined DILL_NO_EPOLL
 #include "epoll.c.inc"
-#elif (defined BSD || defined __APPLE__) && !defined DILL_NO_KQUEUE
+#elif (defined __FreeBSD__ || defined __APPLE__) && !defined DILL_NO_KQUEUE
 #include "kqueue.c.inc"
 #else
 #include "poll.c.inc"

--- a/pollset.h
+++ b/pollset.h
@@ -35,7 +35,7 @@
 /* Defaults. */
 #elif defined __linux__ && !defined DILL_NO_EPOLL
 #include "epoll.h.inc"
-#elif (defined BSD || defined __APPLE__) && !defined DILL_NO_KQUEUE
+#elif (defined __FreeBSD__ || defined __APPLE__) && !defined DILL_NO_KQUEUE
 #include "kqueue.h.inc"
 #else
 #include "poll.h.inc"


### PR DESCRIPTION
This patch is licensed under X11/MIT.

I removed `BSD` because it doesn't seem to be defined in FreeBSD anyway, and I guess other BSDs will be explicitly enumerated when someone will verify library there.

Or I can also add `__NetBSD__` and `__OpenBSD__` hoping it will work there too. 