### PR TITLE
fix clang warning -Wreturn-type

### DIFF
--- a/cr.c
+++ b/cr.c
@@ -394,6 +394,7 @@ int dill_wait(void)  {
        unwinding information will be trimmed if a crash occurs in this
        function. */
     dill_longjmp(ctx->r->ctx);
+    return 0;
 }
 
 static void dill_docancel(struct dill_cr *cr, int id, int err) {


### PR DESCRIPTION
fixes warning on osx: `control may reach end of non-void function [-Wreturn-type]`

