### PR TITLE
Grammar fixes in tutorial.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/man/*.md
+documentation.md

--- a/build_options.html
+++ b/build_options.html
@@ -18,10 +18,10 @@
 <h1 id="libdill-build-options">Libdill build options</h1>
 <p>You can pass the following options to <code>./configure</code>:</p>
 <ul>
-<li><code>--disable-shared</code>: Generate only static library. This option causes tests to be statically linked with libdill thus making debugging easier.<br /></li>
-<li><code>--disable-threads</code>: Can be used with single-threaded programs. It will make libdill a little bit faster and make it not depend on pthread library.<br /></li>
-<li><code>--enable-census</code>: When this option is set the library keeps track of space on stack was used by individual coroutines. It prints the statistics when the process exits.<br /></li>
+<li><code>--disable-shared</code>: Generate only a static library. This option causes tests to be linked with libdill statically, thereby making debugging easier.<br /></li>
+<li><code>--disable-threads</code>: Can be used with single-threaded programs. It will make libdill a little bit faster and make it not depend on the pthread library.<br /></li>
+<li><code>--enable-census</code>: When this option is set, the library keeps track of stack space used by individual coroutines. It prints statistics when the process exits.<br /></li>
 <li><code>--enable-debug</code>: Add debug info to the library.<br /></li>
-<li><code>--enable-valgrind</code>: Valgrind gets confused by libdill's coroutines. Setting this option helps valgrind make sense of what's going on. It's not 100% waterproof but it helps to eliminate many false positives.</li>
+<li><code>--enable-valgrind</code>: Valgrind gets confused by libdill's coroutines. Setting this option helps valgrind make sense of what's going on. It's not 100% foolproof but it helps eliminate many false positives.</li>
 </ul>
 </body>

--- a/build_options.md
+++ b/build_options.md
@@ -2,8 +2,8 @@
 
 You can pass the following options to `./configure`:
 
-* `--disable-shared`: Generate only static library. This option causes tests to be statically linked with libdill thus making debugging easier.
-* `--disable-threads`: Can be used with single-threaded programs. It will make libdill a little bit faster and make it not depend on pthread library.
-* `--enable-census`: When this option is set the library keeps track of space on stack was used by individual coroutines. It prints the statistics when the process exits.
+* `--disable-shared`: Generate only a static library. This option causes tests to be linked with libdill statically, thereby making debugging easier.
+* `--disable-threads`: Can be used with single-threaded programs. It will make libdill a little bit faster and make it not depend on the pthread library.
+* `--enable-census`: When this option is set, the library keeps track of stack space used by individual coroutines. It prints statistics when the process exits.
 * `--enable-debug`: Add debug info to the library.
-* `--enable-valgrind`: Valgrind gets confused by libdill's coroutines. Setting this option helps valgrind make sense of what's going on. It's not 100% waterproof but it helps to eliminate many false positives.
+* `--enable-valgrind`: Valgrind gets confused by libdill's coroutines. Setting this option helps valgrind make sense of what's going on. It's not 100% foolproof but it helps eliminate many false positives.

--- a/compatibility.html
+++ b/compatibility.html
@@ -17,32 +17,32 @@
 </ul>
 <h1 id="compatibility">Compatibility</h1>
 <h3 id="operating-systems">Operating Systems</h3>
-<p>Currently only modern POSIX systems are supported; it has been tested mainly on Linux, FreeBSD and OSX.</p>
-<p>It is likely to work with DragonFlyBSD. NetBSD and OpenBSD probably need <code>DILL_THREAD_FALLBACK</code> to work as Thread Local Storage is unsupported. If you are using libdill on these platforms, please let us know.</p>
-<p>There is currently no support for Windows. Cygwin is very broken, it does not support AF_UNIX properly so no development will progress further with this platform. Work will be done porting libdill to use Mingw and Windows IOCP instead, help is welcome.</p>
-<h3 id="compiler">Compiler</h3>
-<p>libdill requires either GCC and Clang. Your mileage may vary with other compilers:</p>
+<p>Currently, only modern POSIX systems are supported. The library has been tested mainly on Linux, FreeBSD, and OSX.</p>
+<p>It is likely to work with DragonFlyBSD as well. NetBSD and OpenBSD will probably need <code>DILL_THREAD_FALLBACK</code> to work as they don't have support for thread local storage. If you are using libdill on these platforms, please let us know.</p>
+<p>There is currently no support for Windows. Cygwin is very broken. It doesn't support <code>AF_UNIX</code> properly, and so no furhter development will be done for this platform.<br />Libdill is planned to be ported to Mingw and Windows IOCP instead. Help is welcome.</p>
+<h3 id="compilers">Compilers</h3>
+<p>libdill requires either GCC and Clang. Your mileage with other compilers may vary:</p>
 <ul>
-<li>Intel's compiler may work, please send a message along if you find it does.<br /></li>
-<li>MSVC compiler will not work, for both reasons of POSIX and C-extensions used.</li>
+<li>Intel compilers may work; please send us a message if you find they do<br /></li>
+<li>The MSVC compiler won't work due to the POSIX features and C extensions in use</li>
 </ul>
-<p>The non-standard language features that are required by libdill are as follows:</p>
+<p>The non-standard language features libdill requires are as follows:</p>
 <ul>
-<li>The GCC-extension <a href="https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Statement-Exprs.html">statement expressions</a> is used in the <code>go</code> macro.<br /></li>
+<li>The <a href="https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Statement-Exprs.html">statement expressions</a> GCC-extension, which is used in the <code>go</code> macro.<br /></li>
 <li>GCC-style inline assembly.</li>
 </ul>
 <p>Compiler features and incompatibilities:</p>
 <ul>
-<li>On x86 and x86-64 platforms, <code>DILL_ARCH_FALLBACK</code> option is incompatible with GCC 6.2.1 when <code>-fstack-protector</code> is enabled. Please compile libdill and your application with <code>-fno-stack-protector</code> if you need to use the fallback. Non-x86 platforms have not been tested with GCC 6.2.1, please report your mileage.<br /></li>
-<li>Address sanitisation and other stack checking features of compilers are likely to break a <code>libdill</code> build.<br /></li>
-<li>x32 addressing probably does not work, this has not been tested yet.</li>
+<li>On x86 and x86-64 platforms, the <code>DILL_ARCH_FALLBACK</code> option is incompatible with GCC 6.2.1 when <code>-fstack-protector</code> is enabled. Please compile libdill and your application with <code>-fno-stack-protector</code> if you need to use the fallback. Non-x86 platforms have not been tested with GCC 6.2.1. Please report your mileage.<br /></li>
+<li>Address sanitisation and other stack checking compiler features are likely to break your <code>libdill</code> build.<br /></li>
+<li>x32 addressing probably doesn't work, this has not been tested yet.</li>
 </ul>
 <h3 id="standard-libraries">Standard Libraries</h3>
 <h4 id="glibc">glibc</h4>
 <p>Incompatibilities:</p>
 <ul>
-<li>Stack fortification is incompatible with libdill. Do not override the default <code>-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0</code> in a libdill build. However, your application may use stack fortification.<br /></li>
-<li>Stack protection does not work with <code>DILL_ARCH_FALLBACK</code> option. To make it work try using <code>-fno-stack-protector</code> option.</li>
+<li>Stack fortification is incompatible with libdill. Do not override the default <code>-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0</code> in a libdill build. Using fortification in your libdill application is possible.<br /></li>
+<li>Stack protection doesn't work with the <code>DILL_ARCH_FALLBACK</code> option. To make it work, try using the <code>-fno-stack-protector</code> option.</li>
 </ul>
 <h4 id="musl">musl</h4>
 <p>Compatible.</p>

--- a/compatibility.md
+++ b/compatibility.md
@@ -3,29 +3,30 @@
 
 ### Operating Systems
 
-Currently only modern POSIX systems are supported; it has been tested mainly on Linux, FreeBSD and OSX.
+Currently, only modern POSIX systems are supported. The library has been tested mainly on Linux, FreeBSD, and OSX.
 
-It is likely to work with DragonFlyBSD. NetBSD and OpenBSD probably need `DILL_THREAD_FALLBACK` to work as Thread Local Storage is unsupported. If you are using libdill on these platforms, please let us know.
+It is likely to work with DragonFlyBSD as well. NetBSD and OpenBSD will probably need `DILL_THREAD_FALLBACK` to work as they don't have support for thread local storage. If you are using libdill on these platforms, please let us know.
 
-There is currently no support for Windows. Cygwin is very broken, it does not support AF_UNIX properly so no development will progress further with this platform. Work will be done porting libdill to use Mingw and Windows IOCP instead, help is welcome.
+There is currently no support for Windows. Cygwin is very broken. It doesn't support `AF_UNIX` properly, and so no furhter development will be done for this platform. 
+Libdill is planned to be ported to Mingw and Windows IOCP instead. Help is welcome.
 
-### Compiler
+### Compilers
 
-libdill requires either GCC and Clang. Your mileage may vary with other compilers:
+libdill requires either GCC and Clang. Your mileage with other compilers may vary:
 
-- Intel's compiler may work, please send a message along if you find it does.
-- MSVC compiler will not work, for both reasons of POSIX and C-extensions used.
+- Intel compilers may work; please send us a message if you find they do
+- The MSVC compiler won't work due to the POSIX features and C extensions in use
 
-The non-standard language features that are required by libdill are as follows:
+The non-standard language features libdill requires are as follows:
 
-- The GCC-extension [statement expressions](https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Statement-Exprs.html) is used in the `go` macro.
+- The [statement expressions](https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Statement-Exprs.html) GCC-extension, which is used in the `go` macro.
 - GCC-style inline assembly.
 
 Compiler features and incompatibilities:
 
-- On x86 and x86-64 platforms, `DILL_ARCH_FALLBACK` option is incompatible with GCC 6.2.1 when `-fstack-protector` is enabled. Please compile libdill and your application with `-fno-stack-protector` if you need to use the fallback. Non-x86 platforms have not been tested with GCC 6.2.1, please report your mileage.
-- Address sanitisation and other stack checking features of compilers are likely to break a `libdill` build.
-- x32 addressing probably does not work, this has not been tested yet.
+- On x86 and x86-64 platforms, the `DILL_ARCH_FALLBACK` option is incompatible with GCC 6.2.1 when `-fstack-protector` is enabled. Please compile libdill and your application with `-fno-stack-protector` if you need to use the fallback. Non-x86 platforms have not been tested with GCC 6.2.1. Please report your mileage.
+- Address sanitisation and other stack checking compiler features are likely to break your `libdill` build.
+- x32 addressing probably doesn't work, this has not been tested yet.
 
 ### Standard Libraries
 
@@ -33,8 +34,8 @@ Compiler features and incompatibilities:
 
 Incompatibilities:
 
-- Stack fortification is incompatible with libdill. Do not override the default `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0` in a libdill build. However, your application may use stack fortification.
-- Stack protection does not work with `DILL_ARCH_FALLBACK` option. To make it work try using `-fno-stack-protector` option.
+- Stack fortification is incompatible with libdill. Do not override the default `-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0` in a libdill build. Using fortification in your libdill application is possible.
+- Stack protection doesn't work with the `DILL_ARCH_FALLBACK` option. To make it work, try using the `-fno-stack-protector` option.
 
 #### musl
 

--- a/gendocs
+++ b/gendocs
@@ -1,0 +1,39 @@
+#!/bin/sh -e
+
+#Lazily convert md->html
+lz_md_to_html()
+{
+    md=$1
+    html=${md%.*}.html
+    if ! [ "$html" -nt "$md" ]; then
+        echo "$html <- $md"
+        {
+            cat templates/header.html
+            pandoc -f markdown_github $md
+            cat templates/footer.html
+        } > $html.tmp
+        #this indirection is for livereload.js to reload smoothly
+        mv $html.tmp $html 
+        #coarsen the timestamp
+        touch -d 'now+1second' $html
+    fi
+}
+g_documentation_md(){
+    if ! [  documentation.html -nt man/ ]; then
+        {
+            cat templates/documentation-header.md
+            for f in man/*.md; do
+                name=$f; name=${name##*/}; name=${name%.*}
+                echo "* [$name](http://libdill.org/man/$name.html)"
+            done 
+            cat templates/documentation-footer.md
+        } > documentation.md
+    fi
+}
+main(){
+    git checkout master -- 'man/*.md'
+    g_documentation_md
+    for f in man/*.md *.md; do lz_md_to_html "$f"; done
+}
+#git add .
+main "$@"

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <li><a href="http://libdill.org/tutorial.html">Tutorial</a></li>
 </ul>
 <p>Libdill is a C library that makes writing <a href="structured-concurrency.html">structured concurrent programs</a> easy.</p>
-<p>The following example launches two concurrent worker functions that print &quot;Hello!&quot; or &quot;World!&quot;, respectively, in random intervals. Program runs for five seconds, then it shuts down.</p>
+<p>The following example launches two concurrent worker functions that print &quot;Hello!&quot; or &quot;World!&quot;, respectively, at random intervals. The program runs for five seconds and then it shuts down.</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="ot">#include &lt;libdill.h&gt;</span>
 <span class="ot">#include &lt;stdio.h&gt;</span>
 <span class="ot">#include &lt;stdlib.h&gt;</span>
@@ -34,7 +34,7 @@ coroutine <span class="dt">void</span> worker(<span class="dt">const</span> <spa
     msleep(now() + <span class="dv">5000</span>);
     <span class="kw">return</span> <span class="dv">0</span>;
 }</code></pre>
-<p>Code using libdill is compiled in standard C way. The only additional requirement is to link it with libdill library:</p>
+<p>Code dependant on libdill is compiled like any other C code. The only extra requirement is that it be linked with libdill library:</p>
 <pre><code>$ cc -ldill -o hello hello.c</code></pre>
-<p>Libdill is licensed under MIT/X11 license.</p>
+<p>Libdill is licensed under the MIT/X11 license.</p>
 </body>

--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 
 Libdill is a C library that makes writing [structured concurrent programs](structured-concurrency.html) easy.
 
-The following example launches two concurrent worker functions that print "Hello!" or "World!", respectively, in random intervals. Program runs for five seconds, then it shuts down.
+The following example launches two concurrent worker functions that print "Hello!" or "World!", respectively, at random intervals. The program runs for five seconds and then it shuts down.
 
 ```c
 #include <libdill.h>
@@ -23,11 +23,11 @@ int main() {
 }
 ```
 
-Code using libdill is compiled in standard C way. The only additional requirement is to link it with libdill library:
+Code dependant on libdill is compiled like any other C code. The only extra requirement is that it be linked with libdill library:
 
 ```
 $ cc -ldill -o hello hello.c
 ```
 
-Libdill is licensed under MIT/X11 license.
+Libdill is licensed under the MIT/X11 license.
 

--- a/structured-concurrency.html
+++ b/structured-concurrency.html
@@ -16,33 +16,33 @@
 <li><a href="http://libdill.org/tutorial.html">Tutorial</a></li>
 </ul>
 <h2 id="what-is-concurrency">What is concurrency?</h2>
-<p>Concurrency means that multiple functions can run independently of each another.</p>
+<p>Concurrency allows multiple functions to run independent of one another.</p>
 <h2 id="how-is-concurrency-implemented-in-libdill">How is concurrency implemented in libdill?</h2>
-<p>Functions that are meant to run concurrently must be annotated by <code>coroutine</code> modifier.</p>
+<p>Functions that are meant to run concurrently must be annotated with the <code>coroutine</code> modifier.</p>
 <pre class="sourceCode c"><code class="sourceCode c">coroutine <span class="dt">void</span> foo(<span class="dt">int</span> arg1, <span class="dt">const</span> <span class="dt">char</span> *arg2);</code></pre>
-<p>To launch the coroutine use <code>go</code> keyword:</p>
+<p>To launch a coroutine, use the <code>go</code> keyword:</p>
 <pre class="sourceCode c"><code class="sourceCode c">go(foo(<span class="dv">34</span>, <span class="st">&quot;ABC&quot;</span>));</code></pre>
-<p>Launching a concurrent function -- a <code>coroutine</code> in libdill terminology -- using <code>go</code> construct as well as switching between multiple running coroutines is extremely fast, it requires only few machine instructions. In other words, coroutines can be used as flow control mechanism, similar to <code>if</code> or <code>while</code>. The performance is comparable.</p>
-<p>However, there's one huge limitation: All the coroutines run on a single CPU core. If you want to take advantage of multiple cores you have to launch multiple threads or processes, presumably as many of them as there are CPU cores on your machine.</p>
-<p>Coroutines are scheduled cooperatively. What that means is that one coroutine has to explicitly yield control of the CPU to allow a different coroutine to run. In the typical case this is done transparently to the user: When coroutine invokes a function that would block (like <code>msleep</code> or<code>chrecv</code>) the CPU is automatically yielded. However, if a coroutine does work without calling any blocking functions it may hold the CPU forever. For these cases there's a <code>yield</code> function to yield the CPU to other coroutines manually.</p>
+<p>Launching concurrent functions — or <code>coroutines</code>, in libdill terminology — using the <code>go</code> construct and switching between them is extremely fast. It requires only a few machine instructions. This makes coroutines a suitable basic flow control mechanism, not unlike the <code>if</code> or <code>while</code> keywords, which have comparable performance.</p>
+<p>Coroutines have one big limitation, though: All coroutines run on a single CPU core. If you want to take advantage of multiple cores, you have to launch multiple threads or processes, presumably as many of them as there are CPU cores on your machine.</p>
+<p>Coroutines are scheduled cooperatively. What that means is that a coroutine has to explicitly yield control of the CPU to allow a different coroutine to run. In a typical scenario, this is done transparently to the user: When a coroutine invokes a function that would block (such as <code>msleep</code> or<code>chrecv</code>), the CPU is automatically yielded. However, if a coroutine runs without calling any blocking functions, it may hold the CPU forever. For these cases, the <code>yield</code> function can be used to manually relinquish the CPU to other coroutines manually.</p>
 <h2 id="what-is-structured-concurrency">What is structured concurrency?</h2>
-<p>Structured concurrency means that lifetimes of concurrent functions are cleanly nested one inside another. If coroutine <code>foo</code> launches coroutine <code>bar</code> then <code>bar</code> must finish before <code>foo</code> finishes.</p>
+<p>Structured concurrency means that lifetimes of concurrent functions are cleanly nested. If coroutine <code>foo</code> launches coroutine <code>bar</code>, then <code>bar</code> must finish before <code>foo</code> finishes.</p>
 <p>This is not structured concurrency:</p>
 <p><img src="index1.jpeg" /></p>
-<p>On the other hand, this is structured concurrency:</p>
+<p>This is structured concurrency:</p>
 <p><img src="index2.jpeg" /></p>
-<p>The goal of structured concurrency is to guarantee encapsulation. If main function calls <code>foo</code> which in turn launches <code>bar</code> in concurrent fashion, main is guaranteed that after <code>foo</code> finishes there are no leftover functions still running in the background.</p>
-<p>What you end up with is a tree of coroutines rooted in the main function and spreading out toward the smallest worker functions. You also think of it as a generalisation of call stack, a call tree, if you will, in which you can walk from any particular function towards the root until you reach the main function:</p>
+<p>The goal of structured concurrency is to guarantee encapsulation. If the <code>main</code> function calls <code>foo</code>, which in turn launches <code>bar</code> in a concurrent fashion, <code>main</code> will be guaranteed that once <code>foo</code> has finished, there will be no leftover functions still running in the background.</p>
+<p>What you end up with is a tree of coroutines rooted in the <code>main</code> function. This tree spreads out towards the smallest worker functions, and you may think of this as a generalisation of the call stack — a call tree, if you will. In it, you can walk from any particular function towards the root until you reach the <code>main</code> function:</p>
 <p><img src="index3.jpeg" /></p>
 <h2 id="how-is-structured-concurrency-implemented-in-libdill">How is structured concurrency implemented in libdill?</h2>
-<p>As with everything that's idiomatic C you have to do it by hand.</p>
-<p>The good news is that it's easy to do.</p>
-<p><code>go</code> construct returns a handle. The handle can be closed thus killing the concurrent function.</p>
+<p>As with all idiomatic C, you have to do it by hand.</p>
+<p>The good news is that it's easy.</p>
+<p>The <code>go</code> construct returns a handle. The handle can be closed, and thereby kill the associated concurrent function.</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="dt">int</span> h = go(foo());
 do_work();
 hclose(h);</code></pre>
-<p>What about function being killed? It may have some resources allocated and we want it to finish cleanly, not leaving any memory or resource leak behind.</p>
-<p>The mechanism is simple. In function being killed by <code>hclose</code> all the blocking calls start returning <code>ECANCELED</code> error. That on one hand forces the function to finish quickly (there's no much you can do without blocking functions anyway) but it also provides a way to clean up:</p>
+<p>What happens to a function that gets killed? It may have some resources allocated, and we want it to finish cleanly, without leaking those resources.</p>
+<p>The mechanism is simple. In a function being killed by <code>hclose</code>, all blocking calls will start failing with the <code>ECANCELED</code> error. On one hand, this forces the function to finish quickly (there's not much you can do without blocking functions); on the other hand, it provides an opportunity for cleanup.</p>
 <pre class="sourceCode c"><code class="sourceCode c">coroutine <span class="dt">void</span> foo(<span class="dt">void</span>) {
     <span class="dt">void</span> *resource = malloc(<span class="dv">1000</span>);
     <span class="kw">while</span>(<span class="dv">1</span>) {
@@ -54,11 +54,11 @@ hclose(h);</code></pre>
     }
 }</code></pre>
 <h2 id="what-about-asynchronous-objects">What about asynchronous objects?</h2>
-<p>Sometimes you don't want to launch a coroutine but rather to create an object that runs coroutines in the background. For example, an object called <code>tcp_connection</code> may run two coroutines, one for asynchronously reading data from the network, one for sending data to the network.</p>
+<p>Sometimes, instead of launching a coroutine, you may want to create an object that runs coroutines in the background.<br />For example, an object called <code>tcp_connection</code> may run two coroutines, one for asynchrounously reading data from and one for asynchronously writing data to the network.</p>
 <p>Still, it would be nice if the object was a node in the calltree, just like a coroutine is.</p>
-<p>In other words, you want a guarantee that once the object is deallocated there are no leftover coroutines running:</p>
+<p>In other words, you may want a guarantee that once the object is deallocated there will be no leftover coroutines running:</p>
 <p><img src="index4.jpeg" /></p>
-<p>And there's no trick there. Just do it in the most straightforward way. Launch the coroutines in function that opens the object and close them in the function the closes the object. Once main function closes the connection object, both sender and receiver coroutines will be automatically stopped.</p>
+<p>And there's no trick there. Just do it in the most straightforward way. Launch the coroutines in the function that opens the object and close them in the function the closes the object. When the main function closes the connection object, both the sender and receiver coroutine will be stopped automatically.</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="kw">struct</span> tcp_connection {
     <span class="dt">int</span> sender;
     <span class="dt">int</span> receiver;

--- a/structured-concurrency.md
+++ b/structured-concurrency.md
@@ -1,52 +1,52 @@
 ## What is concurrency?
 
-Concurrency means that multiple functions can run independently of each another.
+Concurrency allows multiple functions to run independent of one another.
 
 ## How is concurrency implemented in libdill?
 
-Functions that are meant to run concurrently must be annotated by `coroutine` modifier.
+Functions that are meant to run concurrently must be annotated with the `coroutine` modifier.
 
 ```c
 coroutine void foo(int arg1, const char *arg2);
 ```
 
-To launch the coroutine use `go` keyword:
+To launch a coroutine, use the `go` keyword:
 
 ```c
 go(foo(34, "ABC"));
 ```
 
-Launching a concurrent function -- a `coroutine` in libdill terminology -- using `go` construct  as well as switching between multiple running coroutines is extremely fast, it requires only few machine instructions. In other words, coroutines can be used as flow control mechanism, similar to `if` or `while`. The performance is comparable.
+Launching concurrent functions — or `coroutines`, in libdill terminology — using the `go` construct and switching between them is extremely fast. It requires only a few machine instructions. This makes coroutines a suitable basic flow control mechanism, not unlike the `if` or `while` keywords, which have comparable performance.
 
-However, there's one huge limitation: All the coroutines run on a single CPU core. If you want to take advantage of multiple cores you have to launch multiple threads or processes, presumably as many of them as there are CPU cores on your machine.
+Coroutines have one big limitation, though: All  coroutines run on a single CPU core. If you want to take advantage of multiple cores, you have to launch multiple threads or processes, presumably as many of them as there are CPU cores on your machine.
 
-Coroutines are scheduled cooperatively. What that means is that one coroutine has to explicitly yield control of the CPU to allow a different coroutine to run. In the typical case this is done transparently to the user: When coroutine invokes a function that would block (like `msleep` or`chrecv`) the CPU is automatically yielded. However, if a coroutine does work without calling any blocking functions it may hold the CPU forever. For these cases there's a `yield` function to yield the CPU to other coroutines manually.
+Coroutines are scheduled cooperatively. What that means is that a coroutine has to explicitly yield control of the CPU to allow a different coroutine to run. In a typical scenario, this is done transparently to the user: When a coroutine invokes a function that would block (such as `msleep` or`chrecv`), the CPU is automatically yielded. However, if a coroutine runs without calling any blocking functions, it may hold the CPU forever. For these cases, the `yield` function can be used to manually relinquish the CPU to other coroutines manually.
 
 ## What is structured concurrency?
 
-Structured concurrency means that lifetimes of concurrent functions are cleanly nested one inside another. If coroutine `foo` launches coroutine `bar` then `bar` must finish before `foo` finishes.
+Structured concurrency means that lifetimes of concurrent functions are cleanly nested. If coroutine `foo` launches coroutine `bar`, then `bar` must finish before `foo` finishes.
 
 This is not structured concurrency:
 
 ![](index1.jpeg)
 
-On the other hand, this is structured concurrency:
+This is structured concurrency:
 
 ![](index2.jpeg)
 
-The goal of structured concurrency is to guarantee encapsulation. If main function calls `foo` which in turn launches `bar` in concurrent fashion, main is guaranteed that after `foo` finishes there are no leftover functions still running in the background.
+The goal of structured concurrency is to guarantee encapsulation. If the `main` function calls `foo`, which in turn launches `bar` in a concurrent fashion, `main` will be guaranteed that once `foo` has finished, there will be no leftover functions still running in the background.
 
-What you end up with is a tree of coroutines rooted in the main function and spreading out toward the smallest worker functions. You also think of it as a generalisation of call stack, a call tree, if you will, in which you can walk from any particular function towards the root until you reach the main function:
+What you end up with is a tree of coroutines rooted in the `main` function. This tree spreads out towards the smallest worker functions, and you may think of this as a generalisation of the call stack — a call tree, if you will. In it, you can walk from any particular function towards the root until you reach the `main` function:
 
 ![](index3.jpeg)
 
 ## How is structured concurrency implemented in libdill?
 
-As with everything that's idiomatic C you have to do it by hand.
+As with all idiomatic C, you have to do it by hand.
 
-The good news is that it's easy to do.
+The good news is that it's easy.
 
-`go` construct returns a handle. The handle can be closed thus killing the concurrent function.
+The `go` construct returns a handle. The handle can be closed, and thereby kill the associated concurrent function.
 
 ```c
 int h = go(foo());
@@ -54,9 +54,9 @@ do_work();
 hclose(h);
 ```
 
-What about function being killed? It may have some resources allocated and we want it to finish cleanly, not leaving any memory or resource leak behind.
+What happens to a function that gets killed? It may have some resources allocated, and we want it to finish cleanly, without leaking those resources.
 
-The mechanism is simple. In function being killed by `hclose` all the blocking calls start returning `ECANCELED` error. That on one hand forces the function to finish quickly (there's no much you can do without blocking functions anyway) but it also provides a way to clean up:
+The mechanism is simple. In a function being killed by `hclose`, all blocking calls will start failing with the `ECANCELED` error. On one hand, this forces the function to finish quickly (there's not much you can do without blocking functions); on the other hand, it provides an opportunity for cleanup.
 
 ```c
 coroutine void foo(void) {
@@ -73,15 +73,16 @@ coroutine void foo(void) {
 
 ## What about asynchronous objects?
 
-Sometimes you don't want to launch a coroutine but rather to create an object that runs coroutines in the background. For example, an object called `tcp_connection` may run two coroutines, one for asynchronously reading data from the network, one for sending data to the network.
+Sometimes, instead of launching a coroutine, you may want to create an object that runs coroutines in the background.
+For example, an object called `tcp_connection` may run two coroutines, one for asynchrounously reading data from and one for asynchronously writing data to the network.
 
 Still, it would be nice if the object was a node in the calltree, just like a coroutine is.
 
-In other words, you want a guarantee that once the object is deallocated there are no leftover coroutines running:
+In other words, you may want a guarantee that once the object is deallocated there will be no leftover coroutines running:
 
 ![](index4.jpeg)
 
-And there's no trick there. Just do it in the most straightforward way. Launch the coroutines in function that opens the object and close them in the function the closes the object. Once main function closes the connection object, both sender and receiver coroutines will be automatically stopped.
+And there's no trick there. Just do it in the most straightforward way. Launch the coroutines in the function that opens the object and close them in the function the closes the object. When the main function closes the connection object, both the sender and receiver coroutine will be stopped automatically.
 
 ```c
 struct tcp_connection {

--- a/threads.html
+++ b/threads.html
@@ -16,7 +16,7 @@
 <li><a href="http://libdill.org/tutorial.html">Tutorial</a></li>
 </ul>
 <h1 id="threads">Threads</h1>
-<p>You can use libdill in multi-threaded programs. However, there is strict separation between individual threads. You can think of each thread as of separate process.</p>
-<p>In particular, a coroutine created in a thread will be executed in that thread. It will never migrate to a different thread.</p>
-<p>In a similar manner, a handle, such as channel or coroutine handle, created in one thread cannot be used in a different thread.</p>
+<p>You can use libdill in multi-threaded programs. However, individual threads are strictly separated. You may think of each thread as a separate process.</p>
+<p>In particular, a coroutine created in a thread will be executed in that same thread, and it will never migrate to a different one.</p>
+<p>In a similar manner, a handle, such as a channel or a coroutine handle, created in one thread cannot be used in a different thread.</p>
 </body>

--- a/threads.md
+++ b/threads.md
@@ -1,7 +1,7 @@
 # Threads
 
-You can use libdill in multi-threaded programs. However, there is strict separation between individual threads. You can think of each thread as of separate process.
+You can use libdill in multi-threaded programs. However, individual threads are strictly separated. You may think of each thread as a separate process.
 
-In particular, a coroutine created in a thread will be executed in that thread. It will never migrate to a different thread.
+In particular, a coroutine created in a thread will be executed in that same thread, and it will never migrate to a different one.
 
-In a similar manner, a handle, such as channel or coroutine handle, created in one thread cannot be used in a different thread.
+In a similar manner, a handle, such as a channel or a coroutine handle, created in one thread cannot be used in a different thread.

--- a/tutorial.html
+++ b/tutorial.html
@@ -17,7 +17,7 @@
 </ul>
 <h1 id="tutorial">Tutorial</h1>
 <h2 id="introduction">Introduction</h2>
-<p>In this tutorial you will develop a simple TCP &quot;greet&quot; server. The client is meant to connect to it via telnet. After doing so, the server will ask for their name, reply with a greeting and close the connection.</p>
+<p>In this tutorial, you will develop a simple TCP &quot;greet&quot; server. Clients are meant to connect to it by telnet. After a client has connected, the server will ask for their name, reply with a greeting, and then proceed to close the connection.</p>
 <p>An interaction with our server will look like this:</p>
 <pre><code>$ telnet 127.0.0.1 5555
 Trying 127.0.0.1...
@@ -27,9 +27,9 @@ What&#39;s your name?
 Bartholomaeus
 Hello, Bartholomaeus!
 Connection closed by foreign host.</code></pre>
-<p>In the process you will learn how to use coroutines, channels and sockets.</p>
+<p>Throughout the tutorial, you will learn how to use coroutines, channels, and sockets.</p>
 <h2 id="step-1-setting-up-the-stage">Step 1: Setting up the stage</h2>
-<p>First, include libdill and dsock header files. Later on we'll need some functionality from the standard library, so include those headers as well:</p>
+<p>Start by including the libdill and dsock header files. Later we'll need some functionality from the standard library, so include those headers as well:</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="ot">#include &lt;libdill.h&gt;</span>
 <span class="ot">#include &lt;dsock.h&gt;</span>
 <span class="ot">#include &lt;assert.h&gt;</span>
@@ -38,34 +38,33 @@ Connection closed by foreign host.</code></pre>
 <span class="ot">#include &lt;stdlib.h&gt;</span>
 <span class="ot">#include &lt;string.h&gt;</span>
 <span class="ot">#include &lt;unistd.h&gt;</span></code></pre>
-<p>Add the <code>main</code> function. We'll assume, that the first argument, if present, will be the port number to be used by the server. If not specified, we will default to 5555:</p>
+<p>Add a <code>main</code> function. We'll assume that the first argument, if present, will be the port number to be used by the server. If not specified, the port number will default to <em>5555</em>:</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="dt">int</span> main(<span class="dt">int</span> argc, <span class="dt">char</span> *argv[]) {
     <span class="dt">int</span> port = <span class="dv">5555</span>;
     <span class="kw">if</span>(argc &gt; <span class="dv">1</span>) port = atoi(argv[<span class="dv">1</span>]);
 
     <span class="kw">return</span> <span class="dv">0</span>;
 }</code></pre>
-<p>Now we can start doing the actual interesting stuff.</p>
-<p><code>tcp_listen()</code> function can be used to create listening TCP socket. The socket will be used to accept new TCP connections from the clients:</p>
+<p>Now we can move on to the actual interesting stuff.</p>
+<p>The <code>tcp_listen()</code> function creates a listening TCP socket. The socket can be used to accept new TCP connections from clients:</p>
 <pre class="sourceCode c"><code class="sourceCode c">ipaddr addr;
 <span class="dt">int</span> rc = ipaddr_local(&amp;addr, NULL, port, <span class="dv">0</span>);
-assert(rc == <span class="dv">0</span>);
-<span class="dt">int</span> ls = tcp_listen(&amp;addr, <span class="dv">10</span>);
-<span class="kw">if</span>(ls &lt; <span class="dv">0</span>) {
+<span class="kw">if</span> (rc &lt; <span class="dv">0</span>) {
     perror(<span class="st">&quot;Can&#39;t open listening socket&quot;</span>);
     <span class="kw">return</span> <span class="dv">1</span>;
-}</code></pre>
-<p><code>ipaddr_local()</code> function is used to convert textual representation of a local IP address to the actual address. Second argument can be used to specify local network interface to bind to. This is an advanced functionality and you likely won't need it. Conveniently, you can just ignore it and set the argument to <code>NULL</code>. The server will then bind to all available local network interfaces.</p>
-<p>The third argument is, unsurprisingly, the port that the clients will connect to. When testing the program keep in mind that the range of valid port numbers is 1 to 65535 and binding to the ports from 1 to 1023 typically requires superuser privileges.</p>
-<p>If <code>tcp_listen()</code> fails it returns -1 and sets <code>errno</code> to appropriate error code. Libdill/dscok API is in this respect very similar to standard POSIX APIs. What it means is that we can use standard POSIX mechanims -- <code>perror()</code> in this case -- to deal with errors.</p>
-<p>As for errors that are not likely, we'll just use asserts to catch them, so that the tutorial code is kept succint and readable.</p>
-<p>If you run the program at this stage you'll find out that it finishes immediately rather than pausing and waiting for a connection from the client to arrive. That is what <code>tcp_accept()</code> function is for:</p>
+}
+<span class="dt">int</span> ls = tcp_listen(&amp;addr, <span class="dv">10</span>);
+assert( ls &gt;= <span class="dv">0</span> );</code></pre>
+<p>The <code>ipaddr_local()</code> function converts the textual representation of a local IP address to the actual address. Its second argument can be used to specify a local network interface to bind to. This is an advanced feature and you likely won't need it. For now, you can simply ignore it by setting it to <code>NULL</code>. This will cause the server to bind to all local network interfaces available.</p>
+<p>The third argument is, unsurprisingly, the port that clients will connect to. When testing the program, keep in mind that valid port numbers range from <em>1</em> to <em>65535</em> and that binding to ports <em>1</em> through <em>1023</em> will typically require superuser privileges.</p>
+<p>If <code>tcp_listen()</code> fails, it will return <code>-1</code> and <code>set errno</code> to the appropriate error code. The libdill/dscok API is in this respect very similar to standard POSIX APIs. Consequently, we can use standard POSIX error-handling mechanims such as <code>perror()</code> in this case.</p>
+<p>As for unlikely errors, the tutorial will simply use <code>assert</code>s to catch them so as to stay succinct and readable.</p>
+<p>If you run the program at this stage, you'll find out that it terminates immediately without pausing or waiting for a client to connect. That is what the <code>tcp_accept()</code> function is for:</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="dt">int</span> s = tcp_accept(ls, NULL, -<span class="dv">1</span>);
 assert(s &gt;= <span class="dv">0</span>);</code></pre>
 <p>The function returns the newly established connection.</p>
-<p>The third argument of the function is a deadline. We'll cover the deadlines later on in this tutorial. For now, remember that constant -1 can be used to mean 'no deadline' -- if there is no incoming connection the call will block forever.</p>
-<p>Finally, we want to handle many connections from the clients rather than a single one so we put the <code>tcp_accept()</code> call into an infinite loop.</p>
-<p>For now we'll just print a message when new connection is established we won't even check for error and close it immediately:</p>
+<p>Its third argument is a deadline. We'll cover deadlines later on in this tutorial. For now, remember that the constant <code>-1</code> can be used to mean 'no deadline' — if there is no incoming connection, the call will block forever.</p>
+<p>Finally, we want to handle multiple client connections instead of just one so we put the <code>tcp_accept()</code> call into an infinite loop. For now we'll just print a message when a new connection is established. We will close it immediately and not even check for errors:</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="kw">while</span>(<span class="dv">1</span>) {
     <span class="dt">int</span> s = tcp_accept(ls, NULL, -<span class="dv">1</span>);
     assert(s &gt;= <span class="dv">0</span>);
@@ -73,51 +72,50 @@ assert(s &gt;= <span class="dv">0</span>);</code></pre>
     rc = hclose(s);
     assert(rc == <span class="dv">0</span>);
 }</code></pre>
-<p>The source code for this step can be found in dsock repository named <code>tutorial/step1.c</code>. All the following steps will be available in the same directory.</p>
-<p>Build it like this:</p>
+<p>The source code for this step can be found in the dsock repository under tutorial/step1.c. All the other steps that follow are in the same directory.</p>
+<p>Build the program like this:</p>
 <pre><code>$ gcc -o greetserver step1.c -ldill -ldsock</code></pre>
 <p>Then run the resulting executable:</p>
 <pre><code>$ ./greetserver</code></pre>
-<p>The server now waits for a new connection. Establish one from a different terminal using telnet and check whether it works like expected:</p>
+<p>The server is now waiting for a new connection. Use telnet at a different terminal to establish one and then check whether the program works as expected:</p>
 <pre><code>$ telnet 127.0.0.1 5555</code></pre>
-<p>To test whether error hadling works all right try to use invalid port number:</p>
+<p>To test whether error hadling works, try using an invalid port number:</p>
 <pre><code>$ ./greetserver 70000
 Can&#39;t open listening socket: Invalid argument
 $</code></pre>
-<p>Everyting seems to work as expected. Let's now move to the step 2.</p>
+<p>Everything seems to work as expected. Let's now move on to step 2.</p>
 <h2 id="step-2-the-business-logic">Step 2: The business logic</h2>
-<p>When new connection arrives, the first thing that we want to do is to set up the network protocol we'll use. dsock is a library of easily composable microprotocols and thus you can create a wide range of protocols just by plugging different microprotocols each to another, in lego brick fashion. However, in this tutorial we are going to use just a very simple setup. There's the TCP connection we've just created and on top there will be a simple protocol that delimits the TCP bytestream into discrete messages using line breaks (CR+LF) as delimiters:</p>
+<p>When new a connection arrives, the first thing that we want to do is establish the network protocol we'll be using. dsock is a library of easily composable microprotocols that allows you to compose a wide range of protocols just by plugging different microprotocols onto each other in a lego brick fashion. In this tutorial, however, we are going to limit ourselves to just a very simple setup. On top of the TCP connection that we've just created, we'll have a simple protocol that will split the TCP bytestream into discrete messages, using line breaks (<code>CR+LF</code>) as delimiters:</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="dt">int</span> s = crlf_start(s);
 assert(s &gt;= <span class="dv">0</span>);</code></pre>
-<p>Note that <code>hclose()</code> works in recursive manner. Given that our CRLF socket wraps the underlying TCP socket, single call to <code>hclose()</code> will close both of them.</p>
-<p>Once done we can send the &quot;What's your name?&quot; question to the client:</p>
+<p>Note that <code>hclose()</code> works recursively. Given that our CRLF socket wraps an underlying TCP socket, a single call to <code>hclose()</code> will close both of them.</p>
+<p>Once finished with the setup, we can send the &quot;What's your name?&quot; question to the client:</p>
 <pre class="sourceCode c"><code class="sourceCode c">rc = msend(s, <span class="st">&quot;What&#39;s your name?&quot;</span>, <span class="dv">17</span>, -<span class="dv">1</span>);
 <span class="kw">if</span>(rc != <span class="dv">0</span>) <span class="kw">goto</span> cleanup;</code></pre>
-<p>Note that <code>msend()</code> works with messages, not bytes (the name stands for &quot;message send&quot;). Therefore, the data acts as a single unit: either all of it is received or none of it. Also, we don't have to care about delimitation of messages. That's done for us by the CRLF protocol.</p>
-<p>To handle possible errors from <code>msend()</code> (such as when the client closes the connection) add <code>cleanup</code> label before the <code>hclose</code> line and jump to it whenever you want to close the connection and proceed without crashing the server.</p>
+<p>Note that <code>msend()</code> works with messages, not bytes (the name stands for &quot;message send&quot;). Consequently, the data will act as a single unit: either all of it is received or none of it is. Also, we don't have to care about message delimiters. That's done for us by the CRLF protocol.</p>
+<p>To handle possible errors from <code>msend()</code> (such as when the client has closed the connection), add a <code>cleanup</code> label before the <code>hclose</code> line and jump to it whenever you want to close the connection and proceed without crashing the server.</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="dt">char</span> inbuf[<span class="dv">256</span>];
 ssize_t sz = mrecv(s, inbuf, <span class="kw">sizeof</span>(inbuf), -<span class="dv">1</span>);
 <span class="kw">if</span>(sz &lt; <span class="dv">0</span>) <span class="kw">goto</span> cleanup;</code></pre>
-<p>This piece of code simply reads the reply from the client. Reply is a single message which in case of CRLF protocol translates to a single line of text. The function returns number of bytes in the message.</p>
-<p>Having received the reply from the client, we can now construct the greeting and send it to the client. The analysis of this code is left as an exercise to the reader:</p>
+<p>This piece of code simply reads the reply from the client. The reply is a single message, which in the case of the CRLF protocol translates to a single line of text. The function returns the number of bytes in the message.</p>
+<p>Having received a reply, we can now construct the greeting and send it to the client. The analysis of this code is left as an exercise to the reader:</p>
 <pre class="sourceCode c"><code class="sourceCode c">inbuf[sz] = <span class="dv">0</span>;
 <span class="dt">char</span> outbuf[<span class="dv">256</span>];
 rc = snprintf(outbuf, <span class="kw">sizeof</span>(outbuf), <span class="st">&quot;Hello, %s!&quot;</span>, inbuf);
 rc = msend(s, outbuf, rc, -<span class="dv">1</span>);
 <span class="kw">if</span>(rc != <span class="dv">0</span>) <span class="kw">goto</span> cleanup;</code></pre>
-<p>Compile the program and check whether it works like expected!</p>
+<p>Compile the program and check whether it works as expected.</p>
 <h2 id="step-3-making-it-parallel">Step 3: Making it parallel</h2>
-<p>At this point the client can't crash the server, but it can block it. Do the following experiment:</p>
+<p>At this point, the client cannot crash the server, but it can block it. Do the following experiment:</p>
 <ol>
 <li>Start the server.<br /></li>
-<li>From a different terminal start a telnet session and let it hang without entering your name.<br /></li>
-<li>From yet different terminal open a new telnet session.<br /></li>
+<li>At a different terminal, start a telnet session and, without entering your name, let it hang.<br /></li>
+<li>At yet another terminal, open a new telnet session.<br /></li>
 <li>Observe that the second session hangs without even asking you for your name.</li>
 </ol>
-<p>The reason for the behaviour is that the program doesn't even start accepting new connection until the entire dialogue with the client is finished. What we want instead is running any number of dialogues with the clients in parallel. And that is where coroutines kick in.</p>
-<p>Coroutines are very much like threads. They are very lightweight though. Measuring on a modern hardware you can run up to something like twenty million libdill coroutines per second.</p>
-<p>Coroutines are defined using <code>coroutine</code> keyword and launched using <code>go()</code> construct.</p>
-<p>In our case we can move the code performing the dialogue with the client into a separate function and launch it as a coroutine:</p>
+<p>The reason for this behaviour is that the program doesn't even start accepting new connections until the entire dialogue with the client has finished. What we want instead is to run any number of dialogues with clients in parallel. And that is where coroutines kick in.</p>
+<p>Coroutines are defined using the <code>coroutine</code> keyword and launched with the <code>go()</code> construct.</p>
+<p>In our case, we can move the code performing the dialogue with the client into a separate function and launch it as a coroutine:</p>
 <pre class="sourceCode c"><code class="sourceCode c">coroutine <span class="dt">void</span> dialogue(<span class="dt">int</span> s) {
     <span class="dt">int</span> rc = msend(s, <span class="st">&quot;What&#39;s your name?&quot;</span>, <span class="dv">17</span>, -<span class="dv">1</span>);
 
@@ -141,30 +139,30 @@ cleanup:
         assert(cr &gt;= <span class="dv">0</span>);
     }
 }</code></pre>
-<p>Let's compile it and try the initial experiment once again. As can be seen, one client now cannot block another one. Great. Let's move on.</p>
+<p>Let's compile it and try the initial experiment once again. As can be seen, one client now cannot block another one. Excellent. Let's move on.</p>
 <h2 id="step-4-deadlines">Step 4: Deadlines</h2>
-<p>File descriptors can be a scarce resource. If a client connects to greetserver and lets the dialogue hang without entering the name, one file descriptor on the server side is, for all practical purposes, wasted.</p>
-<p>To deal with the problem we are going to timeout the whole client/server dialogue. If it takes more than 10 seconds, server will kill the connection straight away.</p>
-<p>One thing to note is that libdill uses deadlines rather than more conventional timeouts. In other words, you specify the time instant when you want the operation to finish rather than maximum time it should take to run. To construct deadlines easily, libdill provides <code>now()</code> function. The deadline is expressed in milliseconds so you can create a deadline 10 seconds in the future like this:</p>
+<p>File descriptors can be a scarce resource. If a client connects to the greetserver and lets the dialogue hang without entering a name, one file descriptor on the server side is, for all intents and purposes, wasted.</p>
+<p>To deal with the problem, we are going to timeout the whole client/server dialogue. If it takes more than <em>10</em> seconds, the server will kill the connection at once.</p>
+<p>One thing to note is that libdill uses deadlines rather than the more conventional timeouts. In other words, you specify the time instant by which you want the operation to finish rather than the maximum time it should take to run it. To construct deadlines easily, libdill provides the <code>now()</code> function. The deadline is expressed in milliseconds, which means you can create a deadline <em>10</em> seconds in the future as follows:</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="dt">int64_t</span> deadline = now() + <span class="dv">10000</span>;</code></pre>
-<p>Further, you have to modify all the potentially blocking function calls in the program to take the deadline parameter. In our case:</p>
+<p>Furthermore, you have to modify all potentially blocking function calls in the program to take the deadline parameter. In our case:</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="dt">int</span> rc = msend(s, <span class="st">&quot;What&#39;s your name?&quot;</span>, <span class="dv">17</span>, deadline);
 <span class="kw">if</span>(rc != <span class="dv">0</span>) <span class="kw">goto</span> cleanup;
 <span class="dt">char</span> inbuf[<span class="dv">256</span>];
 ssize_t sz = mrecv(s, inbuf, <span class="kw">sizeof</span>(inbuf), deadline);
 <span class="kw">if</span>(sz &lt; <span class="dv">0</span>) <span class="kw">goto</span> cleanup;</code></pre>
-<p>Note that <code>errno</code> is set to <code>ETIMEDOUT</code> in case the deadline is reached. However, we treat all the errors in the same way (by closing the connection) and thus we don't have to do any specific provisions for the deadline case.</p>
-<h2 id="step-5-communicating-among-coroutines">Step 5: Communicating among coroutines</h2>
-<p>Imagine we want to keep statistics in the greetserver: Number of overall connections, number of those that are active at the moment and number of those that have failed.</p>
-<p>In a classic thread-based application we would keep the statistics in global variables and synchronise access to them using mutexes.</p>
-<p>With libdill, however, we are aiming at &quot;concurrency by message passing&quot; and thus we are going to implement the feature in a different way.</p>
-<p>We will create a new coroutine that will keep track of the statistics and a channel that will be used by <code>dialogue()</code> coroutines to communicate with it:</p>
+<p>Note that <code>errno</code> is set to <code>ETIMEDOUT</code> if the deadline is reached. Since we're treating all errors the same (by closing the connection), we don't make any specific provisions for deadline expiries.</p>
+<h2 id="step-5-communication-among-coroutines">Step 5: Communication among coroutines</h2>
+<p>Suppose we want the greetserver to keep statistics: The overall number of connections made, the number of those that are active at the moment and the number of those that have failed.</p>
+<p>In a classic, thread-based application, we would keep the statistics in global variables and synchronise access to them using mutexes.</p>
+<p>With libdill, however, we aim at &quot;concurrency by message passing&quot;, and so we are going to implement the feature in a different way.</p>
+<p>We will create a new coroutine that will keep track of the statistics and a channel that will be used by the <code>dialogue()</code> coroutines to communicate with it:</p>
 <p><img src="tutorial1.png"/></p>
-<p>First, we define values that will be passed through the channel:</p>
+<p>First, we define the values that will be passed through the channel:</p>
 <pre class="sourceCode c"><code class="sourceCode c"><span class="ot">#define CONN_ESTABLISHED 1</span>
 <span class="ot">#define CONN_SUCCEEDED 2</span>
 <span class="ot">#define CONN_FAILED 3</span></code></pre>
-<p>Now we can create the channel and pass it to <code>dialogue()</code> coroutines:</p>
+<p>Now we can create the channel and pass it to the <code>dialogue()</code> coroutines:</p>
 <pre class="sourceCode c"><code class="sourceCode c">coroutine <span class="dt">void</span> dialogue(<span class="dt">int</span> s, <span class="dt">int</span> ch) {
     ...
 }
@@ -185,10 +183,10 @@ ssize_t sz = mrecv(s, inbuf, <span class="kw">sizeof</span>(inbuf), deadline);
         assert(cr &gt;= <span class="dv">0</span>);
     }
 }</code></pre>
-<p>The argument to <code>chmake()</code> is the type of the values that will be passed through the channel. In our case, they are simple integers.</p>
+<p>The argument to <code>chmake()</code> is the type of values that will be passed through the channel. In our case, the type is simply an integer.</p>
 <p>Libdill channels are &quot;unbuffered&quot;. In other words, the sending coroutine will block each time until the receiving coroutine can process the message.</p>
-<p>This kind of behaviour could, in theory, become a bottleneck, however, in our case we assume that <code>statistics()</code> coroutine will be extremely fast and not likely to turn into a performance bottleneck.</p>
-<p>At this point we can implement the <code>statistics()</code> coroutine that will run forever in a busy loop and collect the statistics from all the <code>dialogue()</code> coroutines. Each time the statistics change, it will print them to <code>stdout</code>:</p>
+<p>This kind of behaviour could, in theory, become a bottleneck, however, in our case we assume that the <code>statistics()</code> coroutine will be extremely fast and not turn into one.</p>
+<p>At this point we can implement the <code>statistics()</code> coroutine, which will run forever in a busy loop and collect statistics from all the <code>dialogue()</code> coroutines. Each time the statistics change, it will print them to <code>stdout</code>:</p>
 <pre class="sourceCode c"><code class="sourceCode c">coroutine <span class="dt">void</span> statistics(<span class="dt">int</span> ch) {
     <span class="dt">int</span> active = <span class="dv">0</span>;
     <span class="dt">int</span> succeeded = <span class="dv">0</span>;
@@ -230,8 +228,8 @@ ssize_t sz = mrecv(s, inbuf, <span class="kw">sizeof</span>(inbuf), deadline);
     ...
 
 }</code></pre>
-<p><code>chrecv()</code> function will retrieve one message from the channel or block if there is none available. At the moment we are not sending anything to the channel, so the coroutine will simply block forever.</p>
-<p>To fix that, let's modify <code>dialogue()</code> coroutine to send some messages to the channel. <code>chsend()</code> function will be used to do that:</p>
+<p>The <code>chrecv()</code> function will retrieve one message from the channel or block if there is none available. At the moment we are not sending anything to it, so the coroutine will simply block forever.</p>
+<p>To fix that, let's modify the <code>dialogue()</code> coroutine to send some messages to the channel. The <code>chsend()</code> function will be used to do that:</p>
 <pre class="sourceCode c"><code class="sourceCode c">coroutine <span class="dt">void</span> dialogue(<span class="dt">int</span> s, <span class="dt">int</span> ch) {
     <span class="dt">int</span> op = CONN_ESTABLISHED;
     <span class="dt">int</span> rc = chsend(ch, &amp;op, <span class="kw">sizeof</span>(op), -<span class="dv">1</span>);
@@ -246,13 +244,13 @@ cleanup:
     rc = hclose(s);
     assert(rc == <span class="dv">0</span>);
 }</code></pre>
-<p>Now compile the server and run it. Create a telnet session and let it timeout. The output on the server side will look like this:</p>
+<p>Now recompile the server and run it. Create a telnet session and let it time out. The output on the server side will look like this:</p>
 <pre><code>$ ./greetserver
 active: 1      succeeded: 0      failed: 0
 active: 0      succeeded: 0      failed: 1</code></pre>
-<p>The first line is displayed when the connection is established: There is one active connection and no connection have succeeded or failed yet.</p>
-<p>Second line shows up when the connection times out: There are no active connection any longer and one connection have failed in the past.</p>
-<p>Now try pressing enter in telnet when asked for the name. The connection is terminated by server immediately, without sending the greeting and the server log reports one failed connection. What's going on here?</p>
-<p>The reason for the bahavior is that CRLF protocol treats an empty line as a connection termination request. Thus, when you press enter in telnet, you send an empty line whicha causes <code>mrecv()</code> on the server side to return <code>EPIPE</code> error which stands for &quot;connection terminated by the peer&quot;. Server thus jumps directly to the cleanup code.</p>
-<p>We are done with the tutorial now. Enjoy your time with the library!</p>
+<p>The first line is displayed when the connection is established: There is one active connection and no connection has succeeded or failed yet.</p>
+<p>The second line shows up when the connection times out: There are no active connection anymore and one connection has failed so far.</p>
+<p>Now try pressing enter in telnet when asked for your name. The connection will be terminated by the server immediately, without sending the greeting, and the server log will report one failed connection. What's going on here?</p>
+<p>The reason for the bahavior is that the CRLF protocol treats an empty line as a connection termination request. Thus, when you press enter in telnet, you send an empty line which causes <code>mrecv()</code> on the server side to return the <code>EPIPE</code> error, which represents &quot;connection terminated by peer&quot;. The server will jump directly into to the cleanup code.</p>
+<p>And that's the end of the tutorial. Enjoy your time with the library!</p>
 </body>

--- a/tutorial.md
+++ b/tutorial.md
@@ -3,7 +3,7 @@
 
 ## Introduction
 
-In this tutorial you will develop a simple TCP "greet" server. The client is meant to connect to it via telnet. After doing so, the server will ask for their name, reply with a greeting and close the connection.
+In this tutorial, you will develop a simple TCP "greet" server. Clients are meant to connect to it by telnet. After a client has connected, the server will ask for their name, reply with a greeting, and then proceed to close the connection.
 
 An interaction with our server will look like this:
 
@@ -17,12 +17,11 @@ Bartholomaeus
 Hello, Bartholomaeus!
 Connection closed by foreign host.
 ```
-
-In the process you will learn how to use coroutines, channels and sockets.
+Throughout the tutorial, you will learn how to use coroutines, channels, and sockets.
 
 ## Step 1: Setting up the stage
 
-First, include libdill and dsock header files. Later on we'll need some functionality from the standard library, so include those headers as well:
+Start by including the libdill and dsock header files. Later we'll need some functionality from the standard library, so include those headers as well:
     
 ```c
 #include <libdill.h>
@@ -35,7 +34,7 @@ First, include libdill and dsock header files. Later on we'll need some function
 #include <unistd.h>
 ```
 
-Add the `main` function. We'll assume, that the first argument, if present, will be the port number to be used by the server. If not specified, we will default to 5555:
+Add a `main` function. We'll assume that the first argument, if present, will be the port number to be used by the server. If not specified, the port number will default to *5555*:
 
 ```c
 int main(int argc, char *argv[]) {
@@ -46,30 +45,30 @@ int main(int argc, char *argv[]) {
 }
 ```
 
-Now we can start doing the actual interesting stuff.
+Now we can move on to the actual interesting stuff.
 
-`tcp_listen()` function can be used to create listening TCP socket. The socket will be used to accept new TCP connections from the clients:
+The `tcp_listen()` function creates a listening TCP socket. The socket can be used to accept new TCP connections from clients:
 
 ```c
 ipaddr addr;
 int rc = ipaddr_local(&addr, NULL, port, 0);
-assert(rc == 0);
-int ls = tcp_listen(&addr, 10);
-if(ls < 0) {
+if (rc < 0) {
     perror("Can't open listening socket");
     return 1;
 }
+int ls = tcp_listen(&addr, 10);
+assert( ls >= 0 );
 ```
 
-`ipaddr_local()` function is used to convert textual representation of a local IP address to the actual address. Second argument can be used to specify local network interface to bind to. This is an advanced functionality and you likely won't need it. Conveniently, you can just ignore it and set the argument to `NULL`. The server will then bind to all available local network interfaces.
+The `ipaddr_local()` function converts the textual representation of a local IP address to the actual address. Its second argument can be used to specify a local network interface to bind to. This is an advanced feature and you likely won't need it. For now, you can simply ignore it by setting it to `NULL`. This will cause the server to bind to all local network interfaces available.
 
-The third argument is, unsurprisingly, the port that the clients will connect to. When testing the program keep in mind that the range of valid port numbers is 1 to 65535 and binding to the ports from 1 to 1023 typically requires superuser privileges.
+The third argument is, unsurprisingly, the port that clients will connect to.  When testing the program, keep in mind that valid port numbers range from *1* to *65535* and that binding to ports *1* through *1023* will typically require superuser privileges.
 
-If `tcp_listen()` fails it returns -1 and sets `errno` to appropriate error code. Libdill/dscok API is in this respect very similar to standard POSIX APIs. What it means is that we can use standard POSIX mechanims -- `perror()` in this case -- to deal with errors.
+If `tcp_listen()` fails, it will return `-1` and `set errno` to the appropriate error code. The libdill/dscok API is in this respect very similar to standard POSIX APIs. Consequently, we can use standard POSIX error-handling mechanims such as `perror()` in this case.
 
-As for errors that are not likely, we'll just use asserts to catch them, so that the tutorial code is kept succint and readable.
+As for unlikely errors, the tutorial will simply use `assert`s to catch them so as to stay succinct and readable.
 
-If you run the program at this stage you'll find out that it finishes immediately rather than pausing and waiting for a connection from the client to arrive. That is what `tcp_accept()` function is for:
+If you run the program at this stage, you'll find out that it terminates immediately without pausing or waiting for a client to connect. That is what the `tcp_accept()` function is for:
 
 ```c
 int s = tcp_accept(ls, NULL, -1);
@@ -78,11 +77,9 @@ assert(s >= 0);
 
 The function returns the newly established connection.
 
-The third argument of the function is a deadline. We'll cover the deadlines later on in this tutorial. For now, remember that constant -1 can be used to mean 'no deadline' -- if there is no incoming connection the call will block forever.
+Its third argument is a deadline. We'll cover deadlines later on in this tutorial. For now, remember that the constant `-1` can be used to mean 'no deadline' — if there is no incoming connection, the call will block forever.
 
-Finally, we want to handle many connections from the clients rather than a single one so we put the `tcp_accept()` call into an infinite loop.
-
-For now we'll just print a message when new connection is established we won't even check for error and close it immediately:
+Finally, we want to handle multiple client connections instead of just one so we put the `tcp_accept()` call into an infinite loop.  For now we'll just print a message when a new connection is established. We will close it immediately and not even check for errors:
 
 ```c
 while(1) {
@@ -94,9 +91,9 @@ while(1) {
 }
 ```
 
-The source code for this step can be found in dsock repository named `tutorial/step1.c`. All the following steps will be available in the same directory.
+The source code for this step can be found in the dsock repository under tutorial/step1.c. All the other steps that follow are in the same directory.
 
-Build it like this:
+Build the program like this:
 
 ```
 $ gcc -o greetserver step1.c -ldill -ldsock
@@ -108,13 +105,13 @@ Then run the resulting executable:
 $ ./greetserver
 ```
 
-The server now waits for a new connection. Establish one from a different terminal using telnet and check whether it works like expected:
+The server is now waiting for a new connection. Use telnet at a different terminal to establish one and then check whether the program works as expected:
 
 ```
 $ telnet 127.0.0.1 5555
 ```
 
-To test whether error hadling works all right try to use invalid port number:
+To test whether error hadling works, try using an invalid port number:
 
 ```
 $ ./greetserver 70000
@@ -122,29 +119,29 @@ Can't open listening socket: Invalid argument
 $
 ```
 
-Everyting seems to work as expected. Let's now move to the step 2.
+Everything seems to work as expected. Let's now move on to step 2.
 
 ## Step 2: The business logic
 
-When new connection arrives, the first thing that we want to do is to set up the network protocol we'll use. dsock is a library of easily composable microprotocols and thus you can create a wide range of protocols just by plugging different microprotocols each to another, in lego brick fashion. However, in this tutorial we are going to use just a very simple setup. There's the TCP connection we've just created and on top there will be a simple protocol that delimits the TCP bytestream into discrete messages using line breaks (CR+LF) as delimiters:
+When new a connection arrives, the first thing that we want to do is establish the network protocol we'll be using. dsock is a library of easily composable microprotocols that allows you to compose a wide range of protocols just by plugging different microprotocols onto each other in a lego brick fashion.  In this tutorial, however, we are going to limit ourselves to just a very simple setup.  On top of the TCP connection that we've just created, we'll have a simple protocol that will split the TCP bytestream into discrete messages, using line breaks (`CR+LF`) as delimiters:
 
 ```c
 int s = crlf_start(s);
 assert(s >= 0);
 ```
 
-Note that `hclose()` works in recursive manner. Given that our CRLF socket wraps the underlying TCP socket, single call to `hclose()` will close both of them.
+Note that `hclose()` works recursively.  Given that our CRLF socket wraps an underlying TCP socket, a single call to `hclose()` will close both of them.
 
-Once done we can send the "What's your name?" question to the client:
+Once finished with the setup, we can send the "What's your name?" question to the client:
 
 ```c
 rc = msend(s, "What's your name?", 17, -1);
 if(rc != 0) goto cleanup;
 ```
 
-Note that `msend()` works with messages, not bytes (the name stands for "message send"). Therefore, the data acts as a single unit: either all of it is received or none of it. Also, we don't have to care about delimitation of messages. That's done for us by the CRLF protocol.
+Note that `msend()` works with messages, not bytes (the name stands for "message send"). Consequently, the data will act as a single unit: either all of it is received or none of it is. Also, we don't have to care about message delimiters. That's done for us by the CRLF protocol.
 
-To handle possible errors from `msend()` (such as when the client closes the connection) add `cleanup` label before the `hclose` line and jump to it whenever you want to close the connection and proceed without crashing the server.
+To handle possible errors from `msend()` (such as when the client has closed the connection), add a `cleanup` label before the `hclose` line and jump to it whenever you want to close the connection and proceed without crashing the server.
 
 ```c
 char inbuf[256];
@@ -152,9 +149,9 @@ ssize_t sz = mrecv(s, inbuf, sizeof(inbuf), -1);
 if(sz < 0) goto cleanup;
 ```
 
-This piece of code simply reads the reply from the client. Reply is a single message which in case of CRLF protocol translates to a single line of text. The function returns number of bytes in the message.
+This piece of code simply reads the reply from the client. The reply is a single message, which in the case of the CRLF protocol translates to a single line of text. The function returns the number of bytes in the message.
 
-Having received the reply from the client, we can now construct the greeting and send it to the client. The analysis of this code is left as an exercise to the reader:
+Having received a reply, we can now construct the greeting and send it to the client. The analysis of this code is left as an exercise to the reader:
 
 ```c
 inbuf[sz] = 0;
@@ -164,24 +161,22 @@ rc = msend(s, outbuf, rc, -1);
 if(rc != 0) goto cleanup;
 ```
 
-Compile the program and check whether it works like expected!
+Compile the program and check whether it works as expected.
 
 ## Step 3: Making it parallel
 
-At this point the client can't crash the server, but it can block it. Do the following experiment:
+At this point, the client cannot crash the server, but it can block it. Do the following experiment:
 
 1. Start the server.
-2. From a different terminal start a telnet session and let it hang without entering your name.
-3. From yet different terminal open a new telnet session.
+2. At a different terminal, start a telnet session and, without entering your name, let it hang.
+3. At yet another terminal, open a new telnet session.
 4. Observe that the second session hangs without even asking you for your name.
 
-The reason for the behaviour is that the program doesn't even start accepting new connection until the entire dialogue with the client is finished. What we want instead is running any number of dialogues with the clients in parallel. And that is where coroutines kick in.
+The reason for this behaviour is that the program doesn't even start accepting new connections until the entire dialogue with the client has finished. What we want instead is to run any number of dialogues with clients in parallel. And that is where coroutines kick in.
 
-Coroutines are very much like threads. They are very lightweight though. Measuring on a modern hardware you can run up to something like twenty million libdill coroutines per second.
+Coroutines are defined using the `coroutine` keyword and launched with the `go()` construct.
 
-Coroutines are defined using `coroutine` keyword and launched using `go()` construct.
-
-In our case we can move the code performing the dialogue with the client into a separate function and launch it as a coroutine:
+In our case, we can move the code performing the dialogue with the client into a separate function and launch it as a coroutine:
 
 ```c
 coroutine void dialogue(int s) {
@@ -209,21 +204,21 @@ int main(int argc, char *argv[]) {
 }
 ```
 
-Let's compile it and try the initial experiment once again. As can be seen, one client now cannot block another one. Great. Let's move on.
+Let's compile it and try the initial experiment once again. As can be seen, one client now cannot block another one. Excellent. Let's move on.
 
 ## Step 4: Deadlines
 
-File descriptors can be a scarce resource. If a client connects to greetserver and lets the dialogue hang without entering the name, one file descriptor on the server side is, for all practical purposes, wasted.
+File descriptors can be a scarce resource. If a client connects to the greetserver and lets the dialogue hang without entering a name, one file descriptor on the server side is, for all intents and purposes, wasted.
 
-To deal with the problem we are going to timeout the whole client/server dialogue. If it takes more than 10 seconds, server will kill the connection straight away.
+To deal with the problem, we are going to timeout the whole client/server dialogue. If it takes more than *10* seconds, the server will kill the connection at once.
 
-One thing to note is that libdill uses deadlines rather than more conventional timeouts. In other words, you specify the time instant when you want the operation to finish rather than maximum time it should take to run. To construct deadlines easily, libdill provides `now()` function. The deadline is expressed in milliseconds so you can create a deadline 10 seconds in the future like this:
+One thing to note is that libdill uses deadlines rather than the more conventional timeouts. In other words, you specify the time instant by which you want the operation to finish rather than the maximum time it should take to run it. To construct deadlines easily, libdill provides the `now()` function. The deadline is expressed in milliseconds, which means you can create a deadline *10* seconds in the future as follows:
 
 ```c
 int64_t deadline = now() + 10000;
 ```
 
-Further, you have to modify all the potentially blocking function calls in the program to take the deadline parameter. In our case:
+Furthermore, you have to modify all potentially blocking function calls in the program to take the deadline parameter. In our case:
 
 ```c
 int rc = msend(s, "What's your name?", 17, deadline);
@@ -233,21 +228,21 @@ ssize_t sz = mrecv(s, inbuf, sizeof(inbuf), deadline);
 if(sz < 0) goto cleanup;
 ```
 
-Note that `errno` is set to `ETIMEDOUT` in case the deadline is reached. However, we treat all the errors in the same way (by closing the connection) and thus we don't have to do any specific provisions for the deadline case.
+Note that `errno` is set to `ETIMEDOUT` if the deadline is reached. Since we're treating all errors the same (by closing the connection), we don't make any specific provisions for deadline expiries.
 
-## Step 5: Communicating among coroutines
+## Step 5: Communication among coroutines
 
-Imagine we want to keep statistics in the greetserver: Number of overall connections, number of those that are active at the moment and number of those that have failed.
+Suppose we want the greetserver to keep statistics: The overall number of connections made, the number of those that are active at the moment and the number of those that have failed.
 
-In a classic thread-based application we would keep the statistics in global variables and synchronise access to them using mutexes.
+In a classic, thread-based application, we would keep the statistics in global variables and synchronise access to them using mutexes.
 
-With libdill, however, we are aiming at "concurrency by message passing" and thus we are going to implement the feature in a different way.
+With libdill, however, we aim at "concurrency by message passing", and so we are going to implement the feature in a different way.
 
-We will create a new coroutine that will keep track of the statistics and a channel that will be used by `dialogue()` coroutines to communicate with it:
+We will create a new coroutine that will keep track of the statistics and a channel that will be used by the `dialogue()` coroutines to communicate with it:
 
 <img src="tutorial1.png"/>
 
-First, we define values that will be passed through the channel:
+First, we define the values that will be passed through the channel:
 
 ```c
 #define CONN_ESTABLISHED 1
@@ -255,7 +250,7 @@ First, we define values that will be passed through the channel:
 #define CONN_FAILED 3
 ```
 
-Now we can create the channel and pass it to `dialogue()` coroutines:
+Now we can create the channel and pass it to the `dialogue()` coroutines:
 
 
 ```c
@@ -281,13 +276,13 @@ int main(int argc, char *argv[]) {
 }
 ```
 
-The argument to `chmake()` is the type of the values that will be passed through the channel. In our case, they are simple integers.
+The argument to `chmake()` is the type of values that will be passed through the channel. In our case, the type is simply an integer.
 
 Libdill channels are "unbuffered". In other words, the sending coroutine will block each time until the receiving coroutine can process the message.
 
-This kind of behaviour could, in theory, become a bottleneck, however, in our case we assume that `statistics()` coroutine will be extremely fast and not likely to turn into a performance bottleneck.
+This kind of behaviour could, in theory, become a bottleneck, however, in our case we assume that the `statistics()` coroutine will be extremely fast and not turn into one.
 
-At this point we can implement the `statistics()` coroutine that will run forever in a busy loop and collect the statistics from all the `dialogue()` coroutines. Each time the statistics change, it will print them to `stdout`:
+At this point we can implement the `statistics()` coroutine, which will run forever in a busy loop and collect statistics from all the `dialogue()` coroutines.  Each time the statistics change, it will print them to `stdout`:
 
 ```c
 coroutine void statistics(int ch) {
@@ -333,9 +328,9 @@ int main(int argc, char *argv[]) {
 }
 ```
 
-`chrecv()` function will retrieve one message from the channel or block if there is none available. At the moment we are not sending anything to the channel, so the coroutine will simply block forever.
+The `chrecv()` function will retrieve one message from the channel or block if there is none available. At the moment we are not sending anything to it, so the coroutine will simply block forever.
 
-To fix that, let's modify `dialogue()` coroutine to send some messages to the channel. `chsend()` function will be used to do that:
+To fix that, let's modify the `dialogue()` coroutine to send some messages to the channel. The `chsend()` function will be used to do that:
 
 ```c
 coroutine void dialogue(int s, int ch) {
@@ -354,7 +349,7 @@ cleanup:
 }
 ```
 
-Now compile the server and run it. Create a telnet session and let it timeout. The output on the server side will look like this:
+Now recompile the server and run it. Create a telnet session and let it time out. The output on the server side will look like this:
 
 ```
 $ ./greetserver
@@ -362,13 +357,12 @@ active: 1      succeeded: 0      failed: 0
 active: 0      succeeded: 0      failed: 1
 ```
 
-The first line is displayed when the connection is established: There is one active connection and no connection have succeeded or failed yet.
+The first line is displayed when the connection is established: There is one active connection and no connection has succeeded or failed yet.
 
-Second line shows up when the connection times out: There are no active connection any longer and one connection have failed in the past.
+The second line shows up when the connection times out: There are no active connection anymore and one connection has failed so far.
 
-Now try pressing enter in telnet when asked for the name. The connection is terminated by server immediately, without sending the greeting and the server log reports one failed connection. What's going on here?
+Now try pressing enter in telnet when asked for your name. The connection will be terminated by the server immediately, without sending the greeting, and the server log will report one failed connection. What's going on here?
 
-The reason for the bahavior is that CRLF protocol treats an empty line as a connection termination request. Thus, when you press enter in telnet, you send an empty line whicha causes `mrecv()` on the server side to return `EPIPE` error which stands for "connection terminated by the peer". Server thus jumps directly to the cleanup code.
+The reason for the bahavior is that the CRLF protocol treats an empty line as a connection termination request. Thus, when you press enter in telnet, you send an empty line which causes `mrecv()` on the server side to return the `EPIPE` error, which represents "connection terminated by peer". The server will jump directly into to the cleanup code.
 
-We are done with the tutorial now. Enjoy your time with the library!
-
+And that's the end of the tutorial. Enjoy your time with the library!


### PR DESCRIPTION
Grammar fixes in tutorial.md in reference to #58 
Also a faster gendocs scripts (ditch it if you don't like it).