### PR TITLE
Edit manpages

### DIFF
--- a/man/chdone.md
+++ b/man/chdone.md
@@ -1,29 +1,28 @@
 # NAME
 
-chdone - mark the channel as closed
+chdone - mark a channel as closed
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int chdone(int ch);
-```
+**#include** **&lt;libdill.h>**
+
+**int chdone(int** _ch_**);**
 
 # DESCRIPTION
 
-This function is used to let all the users of the channel, that there will be no new messages on the channel, ever.
+This function is used to inform the users of a channel that it's forever closed for new messages.
 
-After `chdone` is called, all attempts to `chsend` or `chrecv` on the channel will fail with `EPIPE` error.
+After **chdone** is called on a channel, any attempts to **chsend** or **chrecv** on it will fail with an **EPIPE** error.
 
 # RETURN VALUE
 
-The function returns 0 in case of success. In case of failure it returns -1 and sets `errno` to one of the following values.
+The function returns 0 on success. On error, it returns -1 and sets _errno_ to one of the following values.
 
 # ERRORS
 
-* `EBADF`: Not a valid handle.
-* `ENOTSUP`: Operation not supported. Presumably, the handle isn't a channel.
-* `EPIPE`:  `chdone` was already called for this channel.
+* **EBADF**: Not a valid handle.
+* **ENOTSUP**: Operation not supported. Presumably, the handle isn't a channel.
+* **EPIPE**:  **chdone** has already been called for this channel.
 
 # EXAMPLE
 

--- a/man/chmake.md
+++ b/man/chmake.md
@@ -4,25 +4,24 @@ chmake - create a channel
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int chmake(size_t itemsz);
-```
+**#include &lt;libdill.h>**
+
+**int chmake(size_t **_itemsz_**);**
 
 # DESCRIPTION
 
-Creates a channel. The parameter is the size of the items to be sent through the channel, in bytes.
+Creates a channel. _itemsz_ is the byte size of the items to be sent through the channel.
 
-The channel is a synchronizationn primitive, not a container. It doesn't store any items.
+A channel is a synchronization primitive, not a container. It doesn't store any items.
 
 # RETURN VALUE
 
-Returns a channel handle. In the case of error it returns -1 and sets `errno` to one of the values below.
+Returns a channel handle. In the case of an error, it returns -1 and sets _errno_ to one of the values below.
 
 # ERRORS
 
-* `ECANCELED`: Current coroutine is in the process of shutting down.
-* `ENOMEM`: Not enough memory to allocate the channel.
+* **ECANCELED**: Current coroutine is in the process of shutting down.
+* **ENOMEM**: Not enough memory to allocate a new channel.
 
 # EXAMPLE
 

--- a/man/chmake_mem.md
+++ b/man/chmake_mem.md
@@ -4,32 +4,32 @@ chmake_mem - create a channel in user-supplied memory
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-struct chmem;
-int chmake_mem(size_t itemsz, struct chmem *mem);
-```
+**#include &lt;libdill.h>**
+
+**struct chmem;**
+
+**int chmake_mem(size_t **_itemsz_**, struct chmem **\*_mem_**);**
 
 # DESCRIPTION
 
 Creates a channel in user-supplied memory.
 
-First parameter is the size of the items to be sent through the channel, in bytes.
+_itemsz_ is the byte size of the items to be sent through the channel.
 
-Second parameter is the memory to store channel data in. The memory cannot be deallocated before all handles referring to the channel are closed using `hclose` function. Otherwise, undefined behaviour ensues.
+_mem_ is the memory to store channel data in. The memory must not be deallocated before all handles referring to the channel are closed with the **hclose** function, or the behavior is undefined.
 
-Do not use this function unless you are hyper-otimizing your code and you want to avoid a single memory allocation per channel. Whenever possible, use `chmake` instead.
+Do not use this function unless you are hyper-optimizing your code and you want to avoid a single memory allocation per channel. Whenever possible, use **chmake** instead.
 
-The channel is a synchronizationn primitive, not a container. It doesn't store any items.
+The channel is a synchronization primitive, not a container. It doesn't store any items.
 
 # RETURN VALUE
 
-Returns a channel handle. In the case of error it returns -1 and sets `errno` to one of the values below.
+Returns a channel handle. In the case of an error, it returns -1 and sets _errno_ to one of the values below.
 
 # ERRORS
 
-* `ECANCELED`: Current coroutine is in the process of shutting down.
-* `EINVAL`: Invalid parameter.
+* **ECANCELED**: Current coroutine is in the process of shutting down.
+* **EINVAL**: Invalid parameter.
 
 # EXAMPLE
 

--- a/man/choose.md
+++ b/man/choose.md
@@ -5,8 +5,6 @@ choose - perform one of multiple channel operations
 # SYNOPSIS
 
 ```c
-#include <libdill.h>
-
 #define CHSEND 1
 #define CHRECV 2
 
@@ -16,38 +14,40 @@ struct chclause {
     void *val;
     size_t len;
 };
-
-int choose(struct chclause *clauses, int nclauses, int64_t deadline);
 ```
+
+**#include &lt;libdill.h>**
+
+**int choose(struct chclause **\*_clauses_**, int** _nclauses_**, int64_t** _deadline_**);**
 
 # DESCRIPTION
 
-Accepts a list of channel operations. Performs one that can be done first. If multiple operations can be done immediately, one that comes earlier in the array is executed.
+Accepts a list of channel operations. Performs one that can be done first. If multiple operations can be done immediately, the one that comes earlier in the array is executed.
 
-`op` is operation code, either `CHSEND` or `CHRECV`. `ch` is a channel handle. `val` is a pointer to buffer to send from or receive to. `len` is size of the buffer, in bytes.
+_op_ is a code denoting the operation to be done, and it's either **CHSEND** or **CHRECV**. _ch_ is a channel handle. _val_ is a pointer to a buffer to send data from or receive data to. _len_ is the byte size of the buffer.
 
-`deadline` is a point in time when the operation should time out. Use `now` function to get current point in time. 0 means immediate timeout, i.e. perform the operation if possible, return without blocking if not. -1 means no deadline, i.e. the call will block forever if the operation cannot be performed.
+_deadline_ is a point in time when the operation should time out. Use the **now** function to get the current point in time. 0 means immediate timeout, i.e., perform the operation if possible or return without blocking if not. -1 means no deadline, i.e., the call will block forever if the operation cannot be performed.
 
-If deadline expires before any operation can be performed, the function fails with `ETIMEDOUT` error.
+If the deadline expires before any operation can be performed, the function will fail with an **ETIMEDOUT** error.
 
 # RETURN VALUE
 
-Returns -1 if an error occured. Index of the clause that caused the function to exit otherwise. Even in the latter case `errno` may be set to indicate a failure.
+Returns -1 if an error occurred. Otherwise, it returns the index of the clause that caused the function to exit. Even in the latter case, _errno_ may be set to indicate failure.
 
 # ERRORS
 
-If function returns -1 it sets `errno` to one of the following values:
+If the function returns -1, _errno_ is set to one of the following values:
 
-* `ECANCELED`: Current coroutine is being shut down.
-* `ETIMEDOUT`: The deadline was exceeded.
+* **ECANCELED**: Current coroutine is being shut down.
+* **ETIMEDOUT**: Deadline has expired.
 
-If function returns index of operation it sets `errno` to one of the following values:
+If the function returns an index, it set _errno_ to one of the following values:
 
-* `0`: Operation completed successfully.
-* `EBADF`: Invalid handle.
-* `EINVAL`: Invalid parameter.
-* `ENOTSUP`: Operation not supported. Presumably, the handle isn't a channel.
-* `EPIPE`: The channel was closed using `chdone` function.
+* 0: Operation completed successfully.
+* **EBADF**: Invalid handle.
+* **EINVAL**: Invalid parameter.
+* **ENOTSUP**: Operation not supported. Presumably, the handle isn't a channel.
+* **EPIPE**: Channel has been closed with **chdone**.
 
 # EXAMPLE
 

--- a/man/chrecv.md
+++ b/man/chrecv.md
@@ -4,33 +4,33 @@ chrecv - receive a message from a channel
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int chrecv(int ch, void *val, size_t len, int64_t deadline);
-```
+
+**#include &lt;libdill.h>**
+
+**int chrecv(int **_ch_**, void **\*_val_**, size_t** _len_**, int64_t** _deadline_**);**
 
 # DESCRIPTION
 
-Retrieves a message from the channel. First parameter is the channel handle. Second points to the buffer to receive the message. Third is the size of the buffer.
+Retrieves a message from a channel. The _ch_ parameter is the channel handle. _val_ points to a buffer to receive the message to. _len_ is the size of the buffer.
 
-The size of the buffer must match the size of elements stored in the channel, as supplied to `chmake` function.
+The size of the buffer must match the size of the elements stored in the channel as supplied to the **chmake** function.
 
-If there's no sender available the function waits until one arrives or until deadline expires.
+If no sender is available, the function waits until one arrives or until the deadline expires.
 
-`deadline` is a point in time when the operation should time out. Use `now` function to get current point in time. 0 means immediate timeout, i.e. perform the operation if possible, return without blocking if not. -1 means no deadline, i.e. the call will block forever if the operation cannot be performed.
+_deadline_ is a point in time when the operation should time out. Use the **now()** function to get your current point in time. 0 means immediate timeout, i.e., perform the operation if possible or return without blocking if not. -1 means no deadline, i.e., the call will block forever if the operation cannot be performed.
 
 # RETURN VALUE
 
-The function returns 0 in case of success or -1 in case of error. In the latter case it sets `errno` to one of the values below.
+The function returns 0 on success. On error, it returns -1 and sets _errno_ to one of the values below.
 
 # ERRORS
 
-* `EBADF`: Invalid handle.
-* `ECANCELED`: Current coroutine is being shut down.
-* `EINVAL`: Invalid parameter.
-* `ENOTSUP`: Operation not supported. Presumably, the handle isn't a channel.
-* `EPIPE`: The channel was closed using `chdone` function.
-* `ETIMEDOUT`: The deadline was reached while waiting for a message.
+* **EBADF**: Invalid handle.
+* **ECANCELED**: Current coroutine is being shut down.
+* **EINVAL**: Invalid parameter.
+* **ENOTSUP**: Operation not supported. Presumably, the handle isn't a channel.
+* **EPIPE**: Channel has been closed with **chdone**.
+* **ETIMEDOUT**: Deadline expired while waiting on a message.
 
 # EXAMPLE
 

--- a/man/chsend.md
+++ b/man/chsend.md
@@ -4,33 +4,32 @@ chsend - send a message to a channel
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int chsend(int ch, const void *val, size_t len, int64_t deadline);
-```
+**#include &lt;libdill.h>**
+
+**int chsend(int ***ch*, **const void** \*_val_**, size_t **_len_**, int64_t **_deadline_**);**
 
 # DESCRIPTION
 
-Send a message to the channel. First parameter is the channel handle. Second points to the buffer that contains the message to send. Third is the size of the buffer.
+Sends a message to a channel. The first parameter is a channel handle. The second one points to a buffer that contains the message to send. The third parameter is the size of the buffer.
 
-The size of the buffer must match the size of elements stored in the channel, as supplied to `chmake` function.
+The size of the buffer must match the size of the elements stored in the channel as supplied to the **chmake** function.
 
-If there's no receiver for the message the function waits until one becomes available or until deadline expires.
+If there's no receiver for the message, the function waits until one becomes available or until the deadline expires.
 
-`deadline` is a point in time when the operation should time out. Use `now` function to get current point in time. 0 means immediate timeout, i.e. perform the operation if possible, return without blocking if not. -1 means no deadline, i.e. the call will block forever if the operation cannot be performed.
+_deadline_ is a point in time when the operation should time out. Use the **now()** function to get your current point in time. 0 means immediate timeout, i.e., perform the operation if possible or return without blocking if not. -1 means no deadline, i.e., the call will block forever if the operation cannot be performed.
 
 # RETURN VALUE
 
-The function returns 0 in case of success or -1 in case of error. In the latter case it sets `errno` to one of the values below.
+The function returns 0 on success. On error, it returns -1 and sets _errno_ to one of the values below.
 
 # ERRORS
 
-* `EBADF`: Invalid handle.
-* `ECANCELED`: Current coroutine is being shut down.
-* `EINVAL`: Invalid parameter.
-* `ENOTSUP`: Operation not supported. Presumably, the handle isn't a channel.
-* `EPIPE`: The channel was closed using `chdone` function.
-* `ETIMEDOUT`: The deadline was reached while waiting for a message.
+* **EBADF**: Invalid handle.
+* **ECANCELED**: Current coroutine is being shut down.
+* **EINVAL**: Invalid parameter.
+* **ENOTSUP**: Operation not supported. Presumably, the handle isn't a channel.
+* **EPIPE**: Channel has been closed with **chdone**.
+* **ETIMEDOUT**: Deadline expired while waiting on a message.
 
 # EXAMPLE
 

--- a/man/fdclean.md
+++ b/man/fdclean.md
@@ -4,16 +4,16 @@ fdclean - erases cached info about a file descriptor
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-void fdclean(int fd);
-```
+**#include &lt;libdill.h>**
+
+**void fdclean(int **_fd_**);**
+
 
 # DESCRIPTION
 
-This function drops any state cached by `libdill` associated with the file descriptor. It has to be called before the file descriptor is closed. If it is not, undefined behaviour may ensue.
+This function drops any state that libdill associates with file descriptor _fd_. It has to be called before the file descriptor is closed. If it is not, the behavior is undefined.
 
-It should also be used when you are temporarily provided with a file descriptor by a third party library, just before returning the descriptor back to the original owner.
+It should also be used with file descriptors provided by third-party libraries, just before returning them back to their original owners.
 
 # RETURN VALUE
 

--- a/man/fdin.md
+++ b/man/fdin.md
@@ -1,39 +1,35 @@
 # NAME
 
-fdin - waits until file descriptor becomes readable
+fdin - waits on a filedescriptor to become readable
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int fdin(int fd, int64_t deadline);
-```
+**#include &lt;libdill.h>**
+
+**int fdin(int** _fd_, **int64_t** _deadline_**);**
 
 # DESCRIPTION
 
-Waits until file descriptor becomes readable or until it gets into an error state. Both options cause successful return from the function. To distinguish between the two outcomes you have to do subsequent read operation on the file descriptor.
+Waits on a file descriptor to either become readable or get into an error state.  Either case leads to a successful return from the function.  To distinguish the two outcomes, follow up with a read operation on the file descriptor.
 
-`deadline` is a point in time when the operation should time out. Use `now` function to get current point in time. 0 means immediate timeout, i.e. return immediately if file descriptor is readable, return without blocking if it is not. -1 means no deadline, i.e. the call will block forever, if needed.
+_deadline_ is a point in time when the operation should time out. Use the **now** function to get your current point in time. 0 means immediate timeout, i.e.,  perform the operation if possible or return without blocking if not. -1 means no deadline, i.e., the call will block forever if need be.
 
 # RETURN VALUE
 
-The function returns 0 in case of success or -1 in case of error. In the latter case is sets `errno` to one of the following values.
+The function returns 0 on success. On error, it returns -1 and sets _errno_ to one of the values below.
 
 # ERRORS
 
-* `EBADF`: Not a file descriptor.
-* `EBUSY`: Another coroutine is already blocked on `fdin` with this file descriptor.
-* `ECANCELED`: Current coroutine is being shut down.
-* `ETIMEDOUT`: Deadline expired while waiting for the file descriptor.
+* **EBADF**: Not a file descriptor.
+* **EBUSY**: Another coroutine already blocked on **fdin** with this file descriptor.
+* **ECANCELED**: Current coroutine is being shut down.
+* **ETIMEDOUT**: Deadline expired while waiting on the file descriptor.
 
 # EXAMPLE
 
-```c
-int result = fcntl(fd, F_SETFL, O_NONBLOCK);
-assert(result == 0);
-while(1) {
-    result = fdin(fd, -1);
-    assert(result == 0);
+```
+c int result = fcntl(fd, F_SETFL, O_NONBLOCK); assert(result == 0); while(1)
+{ result = fdin(fd, -1); assert(result == 0);
     char buf[1024];
     ssize_t len = recv(fd, buf, sizeof(buf), 0);
     assert(len > 0);

--- a/man/fdout.md
+++ b/man/fdout.md
@@ -1,30 +1,28 @@
 # NAME
 
-fdout - waits while file descriptor becomes writeable
+fdout - wait on file descriptor to become writable
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int fdout(int fd, int64_t deadline);
-```
+**#include &lt;libdill.h>**
+**int fdout(int** _fd_**, int64_t** _deadline_**);**
 
 # DESCRIPTION
 
-Waits until file descriptor becomes writeable or until it gets into an error state. Both options cause successful return from the function. To distinguish between the two outcomes you have to do subsequent write operation on the file descriptor.
+Waits on a file descriptor to either become readable or get into an error state.  Either case leads to a successful return from the function.  To distinguish the two outcomes, follow up with a write operation on the file descriptor.
 
-`deadline` is a point in time when the operation should time out. Use `now` function to get current point in time. 0 means immediate timeout, i.e. return immediately if file descriptor is writeable, return without blocking if it is not. -1 means no deadline, i.e. the call will block forever, if needed.
+_deadline_ is a point in time when the operation should time out. Use the **now** function to get your current point in time. 0 means immediate timeout, i.e.,  perform the operation if possible or return without blocking if not. -1 means no deadline, i.e., the call will block forever if need be.
 
 # RETURN VALUE
 
-The function returns 0 in case of success or -1 in case of error. In the latter case is sets `errno` to one of the following values.
+The function returns 0 on success. On error, it returns -1 and sets _errno_ to one of the values below.
 
 # ERRORS
 
-* `EBADF`: Not a file descriptor.
-* `EBUSY`: Another coroutine is already blocked on `fdout` with this file descriptor.
-* `ECANCELED`: Current coroutine is being shut down.
-* `ETIMEDOUT`: Deadline expired while waiting for the file descriptor.
+* **EBADF**: Not a file descriptor.
+* **EBUSY**: Another coroutine already blocked on **fdout** with this file descriptor.
+* **ECANCELED**: Current coroutine is being shut down.
+* **ETIMEDOUT**: Deadline expired while waiting on the file descriptor. 
 
 # EXAMPLE
 

--- a/man/go.md
+++ b/man/go.md
@@ -4,22 +4,17 @@ go - start a coroutine
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int go(expression);
-```
+**#include &lt;libdill.h>**
+
+**int go(**_expression_**);**
 
 # DESCRIPTION
 
-Launches a coroutine that executes the function invocation passed as the argument.
+Launches a coroutine that executes the function invocation passed as argument.  The coroutine is executed concurrently, and its lifetime may exceed the lifetime of the caller.  The return value of the coroutine, if any, is discarded and cannot be retrieved by the caller.
 
-Coroutine is executed in concurrent manner and its lifetime may exceed the lifetime of the caller.
+Any function to be invoked with **go()** must be declared with the **coroutine** specifier.
 
-The return value of the coroutine, if any, is discarded and cannot be retrieved by the caller.
-
-Any function to be invoked using go() must be declared with `coroutine` specifier.
-
-*WARNING*: Coroutine will most likely work even without `coroutine` specifier. However, it may fail in random non-deterministic fashion, depending on a particular combination of compiler, optimisation level and code in question. Also, all arguments to a coroutine must not be function calls. If they are the program may fail non-deterministically. If you need to pass a result of a computation to a coroutine do the computation first, then pass the result as an argument. Instead of:
+*WARNING*: Coroutines will most likely work even without the **coroutine** specifier. However, they may fail in random non-deterministic ways, depending on the code in question and the particular combination of a compiler and optimization level. Additionally, arguments to a coroutine must not be function calls. If they are, the program may fail non-deterministically. If you need to pass a result of a computation to a coroutine, do the computation first, and then pass the result as an argument. Instead of:
 
 ```c
 go(bar(foo(a)));
@@ -34,12 +29,12 @@ go(bar(a));
 
 # RETURN VALUE
 
-Returns a coroutine handle. In the case of error it returns -1 and sets `errno` to one of the values below.
+Returns a coroutine handle. In the case of an error, it returns -1 and sets _errno_ to one of the values below.
 
 # ERRORS
 
-* `ECANCELED`: Current coroutine is in the process of shutting down.
-* `ENOMEM`: Not enough memory to allocate the coroutine stack.
+* **ECANCELED**: Current coroutine is in the process of shutting down.
+* **ENOMEM**: Not enough memory to allocate the coroutine stack.
 
 # EXAMPLE
 

--- a/man/go_mem.md
+++ b/man/go_mem.md
@@ -4,42 +4,39 @@ go_mem - start a coroutine on a user-supplied stack
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int go_mem(expression, void *stk, size_t stklen);
-```
+**#include &lt;libdill.h>**
+
+**int go_mem(**_expression_**, void** \*_stk_, **size_t** _stklen_**);**
 
 # DESCRIPTION
 
-Launches a coroutine that executes the function invocation passed as the argument. The buffer passed in `stk` argument will be used as coroutine stack. The length of the buffer should be specified in `stklen` argument.
+Launches a coroutine that executes the function invocation passed as argument.  The buffer passed in the _stk_ argument will be used as the coroutine's stack.  The length of the buffer should be specified in the _stklen_ argument.
 
-Coroutine is executed in concurrent manner and its lifetime may exceed the lifetime of the caller.
+The coroutine is executed concurrently, and its lifetime may exceed the lifetime of the caller.  The return value of the coroutine, if any, is discarded and cannot be retrieved by the caller.
 
-The return value of the coroutine, if any, is discarded and cannot be retrieved by the caller.
+Any function to be invoked with **go_mem()** must be declared with the **coroutine** specifier.
 
-Any function to be invoked using go_mem() must be declared with `coroutine` specifier.
-
-*WARNING*: Coroutine will most likely work even without `coroutine` specifier. However, it may fail in random non-deterministic fashion, depending on a particular combination of compiler, optimisation level and code in question. Also, all arguments to a coroutine must not be function calls. If they are the program may fail non-deterministically. If you need to pass a result of a computation to a coroutine do the computation first, then pass the result as an argument. Instead of:
+*WARNING*: Coroutines will most likely work even without the **coroutine** specifier. However, they may fail in random non-deterministic ways, depending on the code in question and the particular combination of a compiler and optimization level. Additionally, arguments to a coroutine must not be function calls. If they are, the program may fail non-deterministically. If you need to pass a result of a computation to a coroutine, do the computation first, and then pass the result as an argument. Instead of:
 
 ```c
-go(bar(foo(a)));
+go_mem(bar(foo(a), stk, stklen));
 ```
 
 Do this:
 
 ```c
 int a = foo();
-go(bar(a));
+go_mem(bar(a), stk, stklen);
 ```
 
 # RETURN VALUE
 
-Returns a coroutine handle. In the case of error it returns -1 and sets `errno` to one of the values below.
+Returns a coroutine handle. In the case of an error, it returns -1 and sets _errno_ to one of the values below.
 
 # ERRORS
 
-* `ECANCELED`: Current coroutine is in the process of shutting down.
-* `ENOMEM`: The stack buffer is not large enough to hold the common coroutine bookkeeping info.
+* **ECANCELED**: Current coroutine is in the process of shutting down.
+* **ENOMEM**: Not enough memory to allocate the coroutine stack.
 
 # EXAMPLE
 

--- a/man/hclose.md
+++ b/man/hclose.md
@@ -4,26 +4,26 @@ hclose - hard-cancels a handle
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int hclose(int h);
-```
+**#include &lt;libdill.h>**
+
+**int hclose(int** _h_**);**
 
 # DESCRIPTION
 
 Closes a handle.
 
-Once all handles pointing to the same underlying object are closed the object is deallocated immediately.
+Once all handles pointing to the same underlying object have been closed, the object is deallocated immediately.
 
-The function guarantees that all resources will be deallocated, however, it does not guarantee that handle's work will be fully finished. E.g. it may not flush data to network or similar.
+The function guarantees that all associated resources are deallocated. However, it does
+not guarantee that the handle's work will have been fully finished. E.g., outbound network data may not be flushed.
 
 # RETURN VALUE
 
-Returns 0 in case of success. In case of failure it returns -1 and sets `errno` to one of the following values.
+Returns a coroutine handle. In the case of an error, it returns -1 and sets _errno_ to one of the values.
 
 # ERRORS
 
-* `EBADF`: Invalid handle.
+* **EBADF**: Invalid handle.
 
 # EXAMPLE
 

--- a/man/hdup.md
+++ b/man/hdup.md
@@ -4,24 +4,23 @@ hdup - duplicates a handle
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int hdup(int h);
-```
+**#include &lt;libdill.h>**
+
+**int hdup(int** _h_**);**
 
 # DESCRIPTION
 
-Duplicates a handle. Both handles will refer to the same underlying object.
+Duplicates a handle. The new handle will refer to the same underlying object.
 
-Each duplicate of the handle requires it's own call to `hclose`. The underlying object is deallocated once all the handles pointing to it are closed.
+Each duplicate of a handle requires its own call to **hclose**. The underlying object is deallocated when all handles pointing to it have been closed.
 
 # RETURN VALUE
 
-The duplicated handle in case of success or -1 in case of failure. In the latter case `errno` is set to one of the following values.
+Returns the new handle duplicate on success. On error, -1 is returned and _errno_ is set to one of the following values.
 
 # ERRORS
 
-* `EBADF`: Invalid handle.
+* **EBADF**: Invalid handle.
 
 # EXAMPLE
 

--- a/man/hmake.md
+++ b/man/hmake.md
@@ -5,35 +5,37 @@ hmake - creates a handle
 # SYNOPSIS
 
 ```c
-#include <libdill.h>
-
 struct hvfs {
     void *(*query)(struct hvfs *vfs, const void *type);
     void (*close)(int h);
 };
-
-int hmake(struct hvfs *vfs);
 ```
+
+**#include **&lt;libdill.h>**
+
+**int hmake(struct hvfs **\*_vfs_**);**
 
 # DESCRIPTION
 
-Handle is a user-space equivalent of a file descriptor. Coroutines and channels are represented by handles.
+A handle is the user-space equivalent of a file descriptor. Coroutines and channels are represented by handles.
 
-Unlike with file descriptors though, you can create your own handle type. To do so use `hmake` function.
+Unlike with file descriptors, however, you can use the **hmake** function to create your own type of handle.
 
-The argument is a virtual function table of operations associated with the handle.
+The argument of the function is a virtual-function table of operations associated with the handle.
 
-When implementing the close operation keep in mind that it is not allowed to invoke blocking operations. Blocking operations invoked in the context of close operation will fail with `ECANCELED` error.
+When implementing the **close** operation, keep in mind that invoking blocking
+operations is not allowed, as blocking operations invoked within the context of
+a **close** operation will fail with an **ECANCELED** error.
 
-To close a handle use `hclose` function.
+To close a handle, use the **hclose** function.
 
 # RETURN VALUE
 
-In case of success the function returns a newly allocated handle. In case of failure it returns -1 and sets `errno` to one of the values below.
+Returns the newly allocated handle on success. On error, -1 is returned and _errno_ is set to one of the following values below.
 
 # ERRORS
 
 * `ECANCELED`: Current coroutine is being shut down.
 * `EINVAL`: Invalid argument.
-* `ENOMEM`: Not enough free memory to create the handle.
+* `ENOMEM`: Not enough free memory to create a handle.
 

--- a/man/hquery.md
+++ b/man/hquery.md
@@ -4,23 +4,22 @@ hquery - gets an opaque pointer associated with a handle and a type
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-void *hquery(int h, const void *type);
-```
+**#include &lt;libdill.h>**
+
+**void \*hquery(int** _h_**, const void** \*_type_**);**
 
 # DESCRIPTION
 
-Returns opaque pointer associated with the handle and the type. This function is a fundamental construct for building APIs on top of handles.
+Returns an opaque pointer associated with the passed handle and the type. This function is a fundamental construct for building APIs on top of handles.
 
-Argument `type` is not interpreted in any way. It is used only as an unique ID. An unique ID can be created, for instance, like this:
+The _type_ argument is not interpreted in any way. It is used only as a unique ID. A unique ID can be created, for instance, like this:
 
 ```c
 int foobar_placeholder = 0;
 const void *foobar_type = &foobar_placeholder;
 ```
 
-The return value has no specified semantics, it is an opaque pointer. Typical use case is to return pointer to a table of virtual functions. These virtual functions can be the used to access handle's functionality:
+The return value has no specified semantics. It is an opaque pointer.  One typical use case for it is to return a pointer to a table of function pointers.  These function pointers can then be used to access the handle's functionality:
 
 ```c
 struct foobar_vfs {
@@ -42,16 +41,17 @@ int foo(int h, char *c) {
 }
 ```
 
-Pointers returned by hquery are meant to be cacheable. In other words, if you call `hquery` on the same handle with the same type multiple times, the result should be the same.
+Pointers returned by **hquery** are meant to be cachable. In other words, if you call **hquery** on the same handle with the same type multiple times, the result should be the same.
 
 # RETURN VALUE
 
-An opaque pointer in case of success. In case of failure, `NULL` is returned and `errno` is set to one of the following values.
+Returns an opaque pointer on success. On error, **NULL** is returned and _errno_ is set to one of the following values.
+
 
 # ERRORS
 
-* `EDADF`: Invalid handle.
-* `ENOTSUP`: Provided type parameter doesn't match any of the types supported by the handle.
+* **EDADF**: Invalid handle.
+* **ENOTSUP**: Provided type parameter doesn't match any of the types supported by the handle.
 
 # EXAMPLE
 

--- a/man/msleep.md
+++ b/man/msleep.md
@@ -4,22 +4,21 @@ msleep - waits until deadline expires
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int msleep(int64_t deadline);
-```
+**#include &lt;libdill.h>**
+
+**int msleep(int64_t** _deadline_**);**
 
 # DESCRIPTION
 
-`deadline` is a point in time when the operation should finish. Use `now` function to get current point in time. 0 will cause the function to return without blocking. -1 will cause it to block forever.
+_deadline_ is a point in time when the operation should finish. Use the **now** function to get your current point in time. 0 will cause the function to return without blocking. -1 will cause it to block forever.
 
 # RETURN VALUE
 
-Returns 0 in case of success, -1 in case of error. In the latter case it sets `errno` to one of the values below.
+Returns 0 on success. One error, -1 is returned and _errno_ is set to one of the values below.
 
 # ERRORS
 
-* `ECANCELED`: Current coroutine is being shut down.
+* **ECANCELED**: Current coroutine is being shut down.
 
 # EXAMPLE
 

--- a/man/now.md
+++ b/man/now.md
@@ -4,18 +4,18 @@ now - get current time
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int64_t now(void);
-```
+**#include &lt;libdill.h>**
+
+**int64_t now(void);**
 
 # DESCRIPTION
 
 Returns current time, in milliseconds.
 
-The function is meant to be used for creating deadlines. For example, a point of time one second on from now can be expressed as `now() + 1000`.
+The function is meant for creating deadlines. For example, a point of time one
+second from now can be expressed as **now() + 1000**.
 
-Following values have special meaning and cannot be returned by the function:
+The following values have special meaning and cannot be returned by the function:
 
 * *0*: Immediate deadline.
 * *-1*: Infinite deadline.

--- a/man/yield.md
+++ b/man/yield.md
@@ -4,24 +4,23 @@ yield - yields CPU to other coroutines
 
 # SYNOPSIS
 
-```c
-#include <libdill.h>
-int yield(void);
-```
+**#include &lt;libdill.h>**
+
+**int yield(void);**
 
 # DESCRIPTION
 
-By calling this function you give other coroutines a chance to run.
+By calling this function, you give other coroutines a chance to run.
 
-You should consider using yield() when doing lengthy computations which don't involve natural coroutine switching points such as `chsend`, `chrecv`, `fdin`, `fdout` or `msleep`.
+You should consider using **yield()** when doing lengthy computations which don't have natural coroutine switching points such as **chsend**, **chrecv**, **fdin**, **fdout** or **msleep**.
 
 # RETURN VALUE
 
-The function returns 0 in case of success or -1 in case of error. In the latter case it sets `errno` to one of the following values.
+The function returns 0 on success and -1 on error. In the latter case, it sets _errno_ to one of the following values.
 
 # ERRORS
 
-* `ECANCELED`: Current coroutine is being shut down.
+* **ECANCELED**: Current coroutine is being shut down.
 
 # EXAMPLE
 


### PR DESCRIPTION
- Changed the formatting to make the manpages look like other POSIX manpages
on Linux  (bold constant names, bold synopses, underlined variable names).

- Fixed a few grammar errors.

- Dropped word wrapping out of the few outliers that had it
(I figured it was best left to manpage browsers).