### PR TITLE
Use POSIX timers to poll for external events

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,8 @@ dillinclude_HEADERS = libdill.h
 lib_LTLIBRARIES = libdill.la
 
 libdill_la_SOURCES = \
+    alarm.c \
+    alarm.h \
     chan.c \
     cr.h \
     cr.c \

--- a/alarm.c
+++ b/alarm.c
@@ -1,0 +1,49 @@
+/*
+
+  Copyright (c) 2017 Tai Chi Minh Ralph Eastwood
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+#include <sys/time.h>
+#include <signal.h>
+
+#include "utils.h"
+
+/* Poll count for tracking when we should trigger external events again. */
+int dill_poll_count = 0;
+
+static void dill_ctx_timer_handler(int sig, siginfo_t *si, void *uc) {
+    dill_poll_count++;
+}
+
+int dill_alarm_init(void) {
+    if(dill_fast(dill_poll_count != 0)) return 0;
+    /* Initialize the external event poll timer for 1 second intervals. */
+    struct itimerval its;
+    its.it_value.tv_sec = 1;
+    its.it_value.tv_usec = 0;
+    its.it_interval.tv_sec = its.it_value.tv_sec;
+    its.it_interval.tv_usec = its.it_value.tv_usec;
+    struct sigaction sa;
+    sa.sa_flags = SA_SIGINFO;
+    sa.sa_sigaction = dill_ctx_timer_handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGALRM, &sa, NULL) == -1) return 1;
+    return setitimer(ITIMER_REAL, &its, NULL);
+}

--- a/alarm.c
+++ b/alarm.c
@@ -23,6 +23,7 @@
 #include <sys/time.h>
 #include <signal.h>
 
+#include "libdill.h"
 #include "utils.h"
 
 /* Poll count for tracking when we should trigger external events again. */
@@ -34,6 +35,8 @@ static void dill_ctx_timer_handler(int sig, siginfo_t *si, void *uc) {
 
 int dill_alarm_init(void) {
     if(dill_fast(dill_poll_count != 0)) return 0;
+    /* Call now() once to initialise. */
+    now();
     /* Initialize the external event poll timer for 1 second intervals. */
     struct itimerval its;
     its.it_value.tv_sec = 1;

--- a/alarm.c
+++ b/alarm.c
@@ -23,7 +23,6 @@
 #include <sys/time.h>
 #include <signal.h>
 
-#include "libdill.h"
 #include "utils.h"
 
 /* Poll count for tracking when we should trigger external events again. */
@@ -35,8 +34,6 @@ static void dill_ctx_timer_handler(int sig, siginfo_t *si, void *uc) {
 
 int dill_alarm_init(void) {
     if(dill_fast(dill_poll_count != 0)) return 0;
-    /* Call now() once to initialise. */
-    now();
     /* Initialize the external event poll timer for 1 second intervals. */
     struct itimerval its;
     its.it_value.tv_sec = 1;

--- a/alarm.h
+++ b/alarm.h
@@ -1,0 +1,27 @@
+/*
+
+  Copyright (c) 2017 Tai Chi Minh Ralph Eastwood
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"),
+  to deal in the Software without restriction, including without limitation
+  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+  and/or sell copies of the Software, and to permit persons to whom
+  the Software is furnished to do so, subject to the following conditions:
+  The above copyright notice and this permission notice shall be included
+  in all copies or substantial portions of the Software.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  IN THE SOFTWARE.
+
+*/
+
+/* This variable ticks every second. */
+extern int dill_poll_count;
+
+/* Initialise the alarm signal handler. */
+int dill_alarm_init(void);

--- a/cr.c
+++ b/cr.c
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/time.h>
 
 #if defined DILL_VALGRIND
 #include <valgrind/valgrind.h>

--- a/cr.c
+++ b/cr.c
@@ -88,9 +88,7 @@ static void dill_ctx_timer_handler(int sig, siginfo_t *si, void *uc) {
 #else
     struct dill_ctx_cr *ctx = si->si_value.sival_ptr;
     int or = timer_getoverrun(ctx->timer);
-    if(or) {
-        __sync_lock_test_and_set(&ctx->do_poll, 1);
-    }
+    if(or) __sync_fetch_and_or(&ctx->do_poll, -1);
 #endif
 }
 

--- a/cr.c
+++ b/cr.c
@@ -24,7 +24,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <time.h>
 
 #if defined DILL_VALGRIND
 #include <valgrind/valgrind.h>

--- a/cr.h
+++ b/cr.h
@@ -24,7 +24,6 @@
 #define DILL_CR_INCLUDED
 
 #include <stdint.h>
-#include <signal.h>
 
 #include "libdill.h"
 #include "qlist.h"

--- a/cr.h
+++ b/cr.h
@@ -25,7 +25,11 @@
 
 #include <stdint.h>
 #include <signal.h>
+#ifdef __APPLE__
+#include <sys/time.h>
+#else
 #include <time.h>
+#endif
 
 #include "libdill.h"
 #include "qlist.h"
@@ -97,10 +101,15 @@ struct dill_ctx_cr {
 #if defined DILL_CENSUS
     struct dill_slist census;
 #endif
+#ifdef __APPLE__
+    /* Previous poll count. */
+    int last_poll;
+#else
     /* POSIX timer for polling external events. */
     timer_t timer;
     /* Flag to indicate whether to poll. */
     sig_atomic_t do_poll;
+#endif
 };
 
 struct dill_clause {

--- a/cr.h
+++ b/cr.h
@@ -25,6 +25,7 @@
 
 #include <stdint.h>
 #include <signal.h>
+#include <time.h>
 
 #include "libdill.h"
 #include "qlist.h"

--- a/cr.h
+++ b/cr.h
@@ -25,7 +25,6 @@
 
 #include <stdint.h>
 #include <signal.h>
-#include <sys/time.h>
 
 #include "libdill.h"
 #include "qlist.h"

--- a/cr.h
+++ b/cr.h
@@ -25,11 +25,7 @@
 
 #include <stdint.h>
 #include <signal.h>
-#if defined __APPLE__
 #include <sys/time.h>
-#else
-#include <time.h>
-#endif
 
 #include "libdill.h"
 #include "qlist.h"
@@ -101,15 +97,8 @@ struct dill_ctx_cr {
 #if defined DILL_CENSUS
     struct dill_slist census;
 #endif
-#ifdef __APPLE__
     /* Previous poll count. */
     int last_poll;
-#else
-    /* POSIX timer for polling external events. */
-    timer_t timer;
-    /* Flag to indicate whether to poll. */
-    sig_atomic_t do_poll;
-#endif
 };
 
 struct dill_clause {

--- a/cr.h
+++ b/cr.h
@@ -24,6 +24,7 @@
 #define DILL_CR_INCLUDED
 
 #include <stdint.h>
+#include <signal.h>
 
 #include "libdill.h"
 #include "qlist.h"
@@ -89,14 +90,16 @@ struct dill_ctx_cr {
     struct dill_qlist ready;
     /* All active timers. */
     struct dill_rbtree timers;
-    /* Last time poll was performed. */
-    int64_t last_poll;
     /* The main coroutine. We don't control the creation of the main coroutine's stack,
        so we have to store this info here instead of the top of the stack. */
     struct dill_cr main;
 #if defined DILL_CENSUS
     struct dill_slist census;
 #endif
+    /* POSIX timer for polling external events. */
+    timer_t timer;
+    /* Flag to indicate whether to poll. */
+    sig_atomic_t do_poll;
 };
 
 struct dill_clause {

--- a/cr.h
+++ b/cr.h
@@ -25,7 +25,7 @@
 
 #include <stdint.h>
 #include <signal.h>
-#ifdef __APPLE__
+#if defined __APPLE__
 #include <sys/time.h>
 #else
 #include <time.h>

--- a/ctx.c
+++ b/ctx.c
@@ -21,6 +21,7 @@
 */
 
 #include "ctx.h"
+#include "alarm.h"
 
 #if !defined DILL_THREADS
 
@@ -34,7 +35,9 @@ static void dill_ctx_atexit(void) {
 }
 
 struct dill_ctx *dill_ctx_init(void) {
-    int rc = dill_ctx_cr_init(&dill_ctx_.cr);
+    int rc = dill_alarm_init();
+    dill_assert(rc == 0);
+    rc = dill_ctx_cr_init(&dill_ctx_.cr);
     dill_assert(rc == 0);
     rc = dill_ctx_handle_init(&dill_ctx_.handle);
     dill_assert(rc == 0);
@@ -108,7 +111,10 @@ static void dill_makekey(void) {
 }
 
 struct dill_ctx *dill_ctx_init(void) {
-    int rc = dill_ctx_cr_init(&dill_ctx_.cr);
+    int rc = dill_alarm_init();
+    rc = dill_ctx_cr_init(&dill_ctx_.cr);
+    dill_assert(rc == 0);
+    rc = dill_ctx_cr_init(&dill_ctx_.cr);
     dill_assert(rc == 0);
     rc = dill_ctx_handle_init(&dill_ctx_.handle);
     dill_assert(rc == 0);

--- a/libdill.c
+++ b/libdill.c
@@ -37,14 +37,20 @@
 #include "pollset.h"
 #include "utils.h"
 
+#if defined(__x86_64__) || defined(__i386__)
+#define DILL_NOW_ERROR_US 250
+#define DILL_NOW_MEASURE_UNIT 50
+
 static __attribute__((noinline)) uint64_t dill_now_measure(void) {
     uint64_t start_rdtsc = __rdtsc();
-    usleep(100);
+    usleep(DILL_NOW_MEASURE_UNIT);
     uint64_t stop_rdtsc = __rdtsc();
     int64_t diff_rdtsc = stop_rdtsc - start_rdtsc;
     if(diff_rdtsc < 0) diff_rdtsc = -diff_rdtsc;
-    return diff_rdtsc * 5;
+    /* 50us * 10 = 500us */
+    return diff_rdtsc * (DILL_NOW_ERROR_US/DILL_NOW_MEASURE_UNIT);
 }
+#endif
 
 static int64_t mnow(void) {
 #if defined __APPLE__

--- a/libdill.c
+++ b/libdill.c
@@ -28,21 +28,48 @@
 #include <mach/mach_time.h>
 #endif
 
+#if defined(__x86_64__) || defined(__i386__)
+#include <x86intrin.h>
+#endif
+
 #include "cr.h"
 #include "libdill.h"
 #include "pollset.h"
 #include "utils.h"
 
-int64_t now(void) {
+//static uint64_t rdtsc_diff = 500000000ULL;
+
+static __attribute__((noinline)) uint64_t dill_now_measure(void) {
+    uint64_t start_rdtsc = __rdtsc();
+    usleep(100);
+    uint64_t stop_rdtsc = __rdtsc();
+    int64_t diff_rdtsc = stop_rdtsc - start_rdtsc;
+    if(diff_rdtsc < 0) diff_rdtsc = -diff_rdtsc;
+    //printf("%llu\n", diff_rdtsc * 10);
+    return diff_rdtsc * 5;
+}
+
+static int64_t mnow(void) {
 #if defined __APPLE__
     static mach_timebase_info_data_t dill_mtid = {0};
     if (dill_slow(!dill_mtid.denom))
         mach_timebase_info(&dill_mtid);
     uint64_t ticks = mach_absolute_time();
     return (int64_t)(ticks * dill_mtid.numer / dill_mtid.denom / 1000000);
+#else
+
+#if defined CLOCK_MONOTONIC_COARSE
+    clock_t id = CLOCK_MONOTONIC_COARSE;
+#elif defined CLOCK_MONOTONIC_FAST
+    clock_t id = CLOCK_MONOTONIC_FAST;
 #elif defined CLOCK_MONOTONIC
+    clock_t id = CLOCK_MONOTONIC;
+#else
+#define DILL_NOW_FALLBACK
+#endif
+#if !defined DILL_NOW_FALLBACK
     struct timespec ts;
-    int rc = clock_gettime(CLOCK_MONOTONIC, &ts);
+    int rc = clock_gettime(id, &ts);
     dill_assert (rc == 0);
     return ((int64_t)ts.tv_sec) * 1000 + (((int64_t)ts.tv_nsec) / 1000000);
 #else
@@ -52,6 +79,26 @@ int64_t now(void) {
     int rc = gettimeofday(&tv, NULL);
     dill_assert (rc == 0);
     return ((int64_t)tv.tv_sec) * 1000 + (((int64_t)tv.tv_usec) / 1000);
+#endif
+#endif
+}
+
+int64_t now(void) {
+#if defined(__x86_64__) || defined(__i386__)
+    static int64_t last_tick = 0;
+    static uint64_t last_rdtsc = 0;
+    static uint64_t rdtsc_diff = 0ULL;
+    uint64_t rdtsc = __rdtsc();
+    int64_t diff = rdtsc - last_rdtsc;
+    if(dill_slow(!rdtsc_diff)) rdtsc_diff = dill_now_measure();
+    if(diff < 0) diff = -diff;
+    if(dill_fast(diff < rdtsc_diff))
+        return last_tick;
+    else
+        last_rdtsc = rdtsc;
+    return (last_tick = mnow());
+#else
+    return mnow();
 #endif
 }
 

--- a/libdill.c
+++ b/libdill.c
@@ -39,8 +39,6 @@
 #include "pollset.h"
 #include "utils.h"
 
-
-
 static int64_t mnow(void) {
 #if defined __APPLE__
     static mach_timebase_info_data_t dill_mtid = {0};

--- a/libdill.c
+++ b/libdill.c
@@ -37,15 +37,12 @@
 #include "pollset.h"
 #include "utils.h"
 
-//static uint64_t rdtsc_diff = 500000000ULL;
-
 static __attribute__((noinline)) uint64_t dill_now_measure(void) {
     uint64_t start_rdtsc = __rdtsc();
     usleep(100);
     uint64_t stop_rdtsc = __rdtsc();
     int64_t diff_rdtsc = stop_rdtsc - start_rdtsc;
     if(diff_rdtsc < 0) diff_rdtsc = -diff_rdtsc;
-    //printf("%llu\n", diff_rdtsc * 10);
     return diff_rdtsc * 5;
 }
 

--- a/utils.h
+++ b/utils.h
@@ -65,5 +65,23 @@
         }\
     } while (0)
 
+
+/* Workaround missing __rdtsc in Clang < 3.5 (or Clang < 6.0 on Xcode) */
+#if defined(__x86_64__) || defined(__i386__)
+#if defined __clang__
+#if (!defined(__apple_build_version__) &&\
+        ((__clang_major__ < 3) || ((__clang_major__ == 3) && (__clang_minor__ < 5))))\
+    || (defined(__apple_build_version__) && (__clang_major__ >= 6))
+static inline uint64_t __rdtsc() {
+#if defined __i386__
+    uint64_t x; asm volatile ("rdtsc" : "=A" (x)); return x;
+#else
+    uint64_t a, d; asm volatile ("rdtsc" : "=a" (a), "=d" (d)); return (d<<32) | a;
+#endif
+}
+#endif
+#endif
+#endif
+
 #endif
 

--- a/utils.h
+++ b/utils.h
@@ -71,7 +71,7 @@
 #if defined __clang__
 #if (!defined(__apple_build_version__) &&\
         ((__clang_major__ < 3) || ((__clang_major__ == 3) && (__clang_minor__ < 5))))\
-    || (defined(__apple_build_version__) && (__clang_major__ >= 6))
+    || (defined(__apple_build_version__) && (__clang_major__ < 6))
 static inline uint64_t __rdtsc() {
 #if defined __i386__
     uint64_t x; asm volatile ("rdtsc" : "=A" (x)); return x;


### PR DESCRIPTION
I noticed that to poll for external events, the current clock time is updated a lot more than it needs to be.  This implements POSIX timers which sets an atomic flag for when external events need to be polled.

This halves the time for the context switching and goroutine launching (matching pre- 7791ef2d5fb20ad04e6b863e73ce069eea885ab5) times.