### PR TITLE
Update DNS processing in ipaddr.c

### DIFF
--- a/ipaddr.c
+++ b/ipaddr.c
@@ -287,7 +287,7 @@ int ipaddr_remote(struct ipaddr *addr, const char *name, int port, int mode,
             if(dill_slow(rc < 0)) return -1;
             continue;
         }
-        if(rc == ENOENT)
+        if(rc == ENOENT || (rc >= DNS_EBASE && rc <= DNS_ELAST))
             break;
         if(!ipv4 && it && it->ai_family == AF_INET)
             ipv4 = it;


### PR DESCRIPTION
This change breaks the tight loop when name is unresolvable.

Example code:

```
#include <libdill.h>
#include <dsock.h>

#include <assert.h>
#include <stdio.h>

int main() {
    ipaddr addr;
    int rc = ipaddr_remote(&addr, "nonexistent.com", 80, 3, now() + 1000);
    char buf[255];
    printf("%d: [%s]\n", rc, ipaddr_str(&addr, buf));
}
```

In practice, I've seen rc == `DNS_ENONAME` and `DNS_EFAIL`. Without this patch, the code goes into an infinite tight loop.