### PR TITLE
Fix not storing the returned error code correctly

### DIFF
--- a/tutorial/protocol/step1.c
+++ b/tutorial/protocol/step1.c
@@ -46,7 +46,7 @@ int quux_open(void) {
     self->hvfs.close = quux_hclose;
     self->hvfs.done = quux_hdone;
     int h = hmake(&self->hvfs);
-    if(h < 0) {int err = errno; goto error2;}
+    if(h < 0) {err = errno; goto error2;}
     return h;
 error2:
     free(self);

--- a/tutorial/protocol/step2.c
+++ b/tutorial/protocol/step2.c
@@ -49,7 +49,7 @@ int quux_open(void) {
     self->hvfs.close = quux_hclose;
     self->hvfs.done = quux_hdone;
     int h = hmake(&self->hvfs);
-    if(h < 0) {int err = errno; goto error2;}
+    if(h < 0) {err = errno; goto error2;}
     return h;
 error2:
     free(self);

--- a/tutorial/protocol/step3.c
+++ b/tutorial/protocol/step3.c
@@ -51,7 +51,7 @@ int quux_attach(int u) {
     self->hvfs.done = quux_hdone;
     self->u = u;
     int h = hmake(&self->hvfs);
-    if(h < 0) {int err = errno; goto error2;}
+    if(h < 0) {err = errno; goto error2;}
     return h;
 error2:
     free(self);

--- a/tutorial/protocol/step4.c
+++ b/tutorial/protocol/step4.c
@@ -61,7 +61,7 @@ int quux_attach(int u) {
     self->mvfs.mrecvl = quux_mrecvl;
     self->u = u;
     int h = hmake(&self->hvfs);
-    if(h < 0) {int err = errno; goto error2;}
+    if(h < 0) {err = errno; goto error2;}
     return h;
 error2:
     free(self);

--- a/tutorial/protocol/step5.c
+++ b/tutorial/protocol/step5.c
@@ -65,7 +65,7 @@ int quux_attach(int u) {
     self->senderr = 0;
     self->recverr = 0;
     int h = hmake(&self->hvfs);
-    if(h < 0) {int err = errno; goto error2;}
+    if(h < 0) {err = errno; goto error2;}
     return h;
 error2:
     free(self);

--- a/tutorial/protocol/step6.c
+++ b/tutorial/protocol/step6.c
@@ -74,7 +74,7 @@ int quux_attach(int u, int64_t deadline) {
     if(remote_version != local_version) {err = EPROTO; goto error2;}
 
     int h = hmake(&self->hvfs);
-    if(h < 0) {int err = errno; goto error2;}
+    if(h < 0) {err = errno; goto error2;}
     return h;
 error2:
     free(self);

--- a/tutorial/protocol/step7.c
+++ b/tutorial/protocol/step7.c
@@ -78,7 +78,7 @@ int quux_attach(int u, int64_t deadline) {
     if(remote_version != local_version) {err = EPROTO; goto error2;}
 
     int h = hmake(&self->hvfs);
-    if(h < 0) {int err = errno; goto error2;}
+    if(h < 0) {err = errno; goto error2;}
     return h;
 error2:
     free(self);


### PR DESCRIPTION
Looks like just a typo to me.

GCC warns about this btw:
```
warning: unused variable ‘err’ [-Wunused-variable]
     if(h < 0) {int err = errno; goto error2;}
                    ^
warning: ‘err’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     errno = err;
```


License: X11/MIT
