### PR TITLE
add detached coroutines

### DIFF
--- a/cr.c
+++ b/cr.c
@@ -85,6 +85,7 @@ int dill_ctx_cr_init(struct dill_ctx_cr *ctx) {
        it's called only once and you can't even create a different coroutine
        without calling it. */
     ctx->r = &ctx->main;
+    ctx->detached_cr = NULL;
     dill_qlist_init(&ctx->ready);
     dill_rbtree_init(&ctx->timers);
     /* We can't use now() here as the context is still being intialized. */
@@ -195,6 +196,7 @@ int dill_prologue(sigjmp_buf **jb, void **ptr, size_t len,
     cr->no_blocking2 = 0;
     cr->done = 0;
     cr->mem = *ptr ? 1 : 0;
+    cr->detached = 0;
 #if defined DILL_VALGRIND
     cr->sid = VALGRIND_STACK_REGISTER((char*)(cr + 1) - stacksz, cr);
 #endif
@@ -235,12 +237,26 @@ void dill_epilogue(void) {
     struct dill_ctx_cr *ctx = &dill_getctx->cr;
     /* Mark the coroutine as finished. */
     ctx->r->done = 1;
+    if (ctx->r->detached) {
+        dill_assert(ctx->detached_cr == NULL);
+        ctx->detached_cr = ctx->r;
+    }
     /* If there's a coroutine waiting for us to finish, unblock it now. */
     if(ctx->r->closer)
         dill_cancel(ctx->r->closer, 0);
     /* With no clauses added, this call will never return. */
     dill_assert(dill_slist_empty(&ctx->r->clauses));
     dill_wait();
+}
+
+/* Mark the handle as detached (or destroy if it's done) */
+void dill_detach(int h) {
+    struct dill_cr *cr = hquery(h, dill_cr_type);
+    if (cr->done) {
+        dill_cr_close(&cr->vfs);
+    } else {
+        cr->detached = 1;
+    }
 }
 
 static void *dill_cr_query(struct hvfs *vfs, const void *type) {
@@ -311,9 +327,17 @@ int dill_wait(void)  {
     struct dill_ctx_cr *ctx = &dill_getctx->cr;
     /* Store the context of the current coroutine, if any. */
     if(dill_setjmp(ctx->r->ctx)) {
-        /* We get here once the coroutine is resumed. */
         dill_slist_init(&ctx->r->clauses);
-        errno = ctx->r->err;
+        int r_err = ctx->r->err;
+        /* We get here once the coroutine is resumed. */
+        if (ctx->detached_cr) {
+            dill_assert(ctx->detached_cr != ctx->r);
+
+            struct dill_cr *to_detach = ctx->detached_cr;
+            ctx->detached_cr = NULL;
+            dill_cr_close(&to_detach->vfs);
+        }
+        errno = r_err;
         return ctx->r->id;
     }
     /* For performance reasons, we want to avoid excessive checking of current

--- a/cr.h
+++ b/cr.h
@@ -62,6 +62,8 @@ struct dill_cr {
     unsigned int done : 1;
     /* If true, the coroutine was launched with go_mem. */
     unsigned int mem : 1;
+    /* If true, the coroutine shall be destroyed when it finishes. */
+    unsigned int detached: 1;
     /* When the coroutine handle is being closed, this points to the
        coroutine that is doing the hclose() call. */
     struct dill_cr *closer;
@@ -85,6 +87,8 @@ struct dill_cr {
 struct dill_ctx_cr {
     /* Currently running coroutine. */
     struct dill_cr *r;
+    /* The latest detached coroutine that has finished. */
+    struct dill_cr *detached_cr;
     /* List of coroutines ready for execution. */
     struct dill_qlist ready;
     /* All active timers. */

--- a/libdill.h
+++ b/libdill.h
@@ -99,7 +99,7 @@ DILL_EXPORT extern volatile void *dill_unoptimisable;
 DILL_EXPORT __attribute__((noinline)) int dill_prologue(sigjmp_buf **ctx,
     void **ptr, size_t len, const char *file, int line);
 DILL_EXPORT __attribute__((noinline)) void dill_epilogue(void);
-DILL_EXPORT __attribute__((noinline)) void dill_detach(int h);
+DILL_EXPORT void dill_detach(int h);
 
 /* The following macros use alloca(sizeof(size_t)) because clang
    doesn't support alloca with size zero. */

--- a/libdill.h
+++ b/libdill.h
@@ -99,6 +99,7 @@ DILL_EXPORT extern volatile void *dill_unoptimisable;
 DILL_EXPORT __attribute__((noinline)) int dill_prologue(sigjmp_buf **ctx,
     void **ptr, size_t len, const char *file, int line);
 DILL_EXPORT __attribute__((noinline)) void dill_epilogue(void);
+DILL_EXPORT __attribute__((noinline)) void dill_detach(int h);
 
 /* The following macros use alloca(sizeof(size_t)) because clang
    doesn't support alloca with size zero. */
@@ -222,6 +223,7 @@ DILL_EXPORT __attribute__((noinline)) void dill_epilogue(void);
     })
 
 #define go(fn) go_mem(fn, NULL, 0)
+#define go_detach(h) dill_detach(h)
 
 DILL_EXPORT int yield(void);
 DILL_EXPORT int msleep(int64_t deadline);


### PR DESCRIPTION
Those changes are handy to simplify resource managment and modeled after `ptherad_detach`.