### PR TITLE
avoid assert on exit

### DIFF
--- a/kqueue.c.inc
+++ b/kqueue.c.inc
@@ -82,7 +82,9 @@ void dill_ctx_pollset_term(struct dill_ctx_pollset *ctx) {
        survive a fork. However, implementations seem to disagree.
        On FreeBSD the following function succeeds. On OSX it returns
        EACCESS. Therefore we ignore the return value. */
-    close(ctx->kfd);
+    int kfd = ctx->kfd;
+    ctx->kfd = -1;
+    close(kfd);
     free(ctx->fdinfos);
 }
 
@@ -187,11 +189,17 @@ int dill_pollset_clean(int fd) {
         EV_SET(&evs[nevs], fd, EVFILT_WRITE, EV_DELETE, 0, 0, 0);
         ++nevs;
     }
+    fdi->currevs = 0;
     if(nevs) {
         int rc = kevent(ctx->kfd, evs, nevs, NULL, 0, NULL);
-        dill_assert(rc != -1);
+        if(rc == -1) {
+            if(errno == EBADF && ctx->kfd == -1) {
+                /* Exiting the program. Ignore. */
+                return -1;
+            }
+            dill_assert(rc != -1);
+        }
     }
-    fdi->currevs = 0;
     /* If needed, remove the fd from the changelist. */
     if(fdi->next) {
         uint32_t *pidx = &ctx->changelist;

--- a/kqueue.c.inc
+++ b/kqueue.c.inc
@@ -112,7 +112,7 @@ static void dill_fdcancelout(struct dill_clause *cl) {
 
 int dill_pollset_in(struct dill_fdclause *fdcl, int id, int fd) {
     struct dill_ctx_pollset *ctx = &dill_getctx->pollset;
-    if(dill_slow(fd < 0 || fd >= ctx->nfdinfos)) {errno = EBADF; return -1;}
+    if(dill_slow(fd < 0 || fd >= ctx->nfdinfos || !ctx->fdinfos)) {errno = EBADF; return -1;}
     struct dill_fdinfo *fdi = &ctx->fdinfos[fd];
     /* If not yet cached, check whether fd exists and if so add it
        to pollset. */

--- a/kqueue.c.inc
+++ b/kqueue.c.inc
@@ -82,10 +82,10 @@ void dill_ctx_pollset_term(struct dill_ctx_pollset *ctx) {
        survive a fork. However, implementations seem to disagree.
        On FreeBSD the following function succeeds. On OSX it returns
        EACCESS. Therefore we ignore the return value. */
-    int kfd = ctx->kfd;
+    close(ctx->kfd);
     ctx->kfd = -1;
-    close(kfd);
     free(ctx->fdinfos);
+    ctx->fdinfos = NULL;
 }
 
 static void dill_fdcancelin(struct dill_clause *cl) {
@@ -174,6 +174,10 @@ int dill_pollset_out(struct dill_fdclause *fdcl, int id, int fd) {
 
 int dill_pollset_clean(int fd) {
     struct dill_ctx_pollset *ctx = &dill_getctx->pollset;
+    if(ctx->kfd == -1) {
+        errno = EBADF;
+        return -1;
+    }
     struct dill_fdinfo *fdi = &ctx->fdinfos[fd];
     if(!fdi->cached) return 0;
     /* We cannot clean an fd that someone is waiting for. */


### PR DESCRIPTION
On macOS X, a program would exit with

```
Assert failed: rc != -1 (./kqueue.c.inc:192)
```

without this patch.

Also, crashes at this without the last commit (https://github.com/sustrik/libdill/pull/108/commits/499ba28214c9b549d489855ba8eb4ff02bf56c35):

```
* thread #1, stop reason = signal SIGSEGV: invalid address (fault address: 0x98)
    frame #0: 0x0000000800acb96d libdill.so.14`dill_pollset_in(fdcl=0x00007fffffffe4c0, id=1, fd=4) at kqueue.c.inc:119
   116 	    struct dill_fdinfo *fdi = &ctx->fdinfos[fd];
   117 	    /* If not yet cached, check whether fd exists and if so add it
   118 	       to pollset. */
-> 119 	    if(dill_slow(!fdi->cached)) {
   120 	        struct kevent ev;
   121 	        EV_SET(&ev, fd, EVFILT_READ, EV_ADD, 0, 0, 0);
   122 	        int rc = kevent(ctx->kfd, &ev, 1, NULL, 0, NULL);
(lldb) p fdi
(dill_fdinfo *) $0 = 0x0000000000000080
(lldb) p ctx->fdinfos
(dill_fdinfo *) $1 = 0x0000000000000000
(lldb) up
```