### PR TITLE
compile on freebsd

### DIFF
--- a/tests/ipaddr.c
+++ b/tests/ipaddr.c
@@ -24,6 +24,7 @@
 
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <sys/socket.h>
 #include <string.h>
 
 #include "assert.h"


### PR DESCRIPTION
AF_INET is not defined on FreeBSD without `<sys/socket.h>`.