### PR TITLE
Avoid failing hard in case of DNS configuration failure

### DIFF
--- a/ipaddr.c
+++ b/ipaddr.c
@@ -277,7 +277,12 @@ int ipaddr_remote(struct ipaddr *addr, const char *name, int port, int mode,
     /* Let's do asynchronous DNS query here. */
     struct dns_resolver *resolver = dns_res_open(dill_dns_conf,
         dill_dns_hosts, dill_dns_hints, NULL, dns_opts(), &rc);
-    dill_assert(resolver);
+    if(!resolver) {
+        if(errno == ENFILE || errno == EMFILE) {
+            return -1;
+        }
+        dill_assert(resolver);
+    }
     dill_assert(port >= 0 && port <= 0xffff);
     char portstr[8];
     snprintf(portstr, sizeof(portstr), "%d", port);

--- a/ipaddr.c
+++ b/ipaddr.c
@@ -266,7 +266,7 @@ int ipaddr_remote(struct ipaddr *addr, const char *name, int port, int mode,
         /* TODO: Maybe re-read the configuration once in a while? */
         dill_dns_conf = dns_resconf_local(&rc);
         if(!dill_dns_conf) {
-            errno = EADDRNOTAVAIL;
+            errno = ENOENT;
             return -1;
         }
         dill_dns_hosts = dns_hosts_local(&rc);

--- a/ipaddr.c
+++ b/ipaddr.c
@@ -265,7 +265,10 @@ int ipaddr_remote(struct ipaddr *addr, const char *name, int port, int mode,
     if(dill_slow(!dill_dns_conf)) {
         /* TODO: Maybe re-read the configuration once in a while? */
         dill_dns_conf = dns_resconf_local(&rc);
-        dill_assert(dill_dns_conf);
+        if(!dill_dns_conf) {
+            errno = EADDRNOTAVAIL;
+            return -1;
+        }
         dill_dns_hosts = dns_hosts_local(&rc);
         dill_assert(dill_dns_hosts);
         dill_dns_hints = dns_hints_local(dill_dns_conf, &rc);


### PR DESCRIPTION
If resolv.conf if not available, don't crash the whole program.