### PR TITLE
Fix large DNS replies with non-local resolver.

### DIFF
--- a/dns/dns.h
+++ b/dns/dns.h
@@ -956,6 +956,10 @@ struct dns_hints_i {
 
 unsigned dns_hints_grep(struct sockaddr **, socklen_t *, unsigned, struct dns_hints_i *, struct dns_hints *);
 
+typedef struct {
+    int fd;
+    int want_events; /* DNS_POLLIN or DNS_POLLOUT, or combination */
+} dns_pollfd_result;
 
 /*
  * C A C H E  I N T E R F A C E
@@ -974,7 +978,7 @@ struct dns_cache {
 	int (*check)(struct dns_cache *);
 	struct dns_packet *(*fetch)(struct dns_cache *, int *);
 
-	int (*pollfd)(struct dns_cache *);
+	dns_pollfd_result (*pollfd)(struct dns_cache *);
 	short (*events)(struct dns_cache *);
 	void (*clear)(struct dns_cache *);
 
@@ -1073,7 +1077,7 @@ void dns_so_clear(struct dns_socket *);
 
 int dns_so_events(struct dns_socket *);
 
-int dns_so_pollfd(struct dns_socket *);
+dns_pollfd_result dns_so_pollfd(struct dns_socket *);
 
 int dns_so_poll(struct dns_socket *, int);
 
@@ -1115,7 +1119,7 @@ void dns_res_clear(struct dns_resolver *);
 
 int dns_res_events(struct dns_resolver *);
 
-int dns_res_pollfd(struct dns_resolver *);
+dns_pollfd_result dns_res_pollfd(struct dns_resolver *);
 
 time_t dns_res_timeout(struct dns_resolver *);
 
@@ -1149,7 +1153,7 @@ void dns_ai_clear(struct dns_addrinfo *);
 
 int dns_ai_events(struct dns_addrinfo *);
 
-int dns_ai_pollfd(struct dns_addrinfo *);
+dns_pollfd_result dns_ai_pollfd(struct dns_addrinfo *);
 
 time_t dns_ai_timeout(struct dns_addrinfo *);
 

--- a/ipaddr.c
+++ b/ipaddr.c
@@ -291,14 +291,15 @@ int ipaddr_remote(struct ipaddr *addr, const char *name, int port, int mode,
     while(1) {
         rc = dns_ai_nextent(&it, ai);
         if(rc == EAGAIN) {
-            int fd = dns_ai_pollfd(ai);
-            dill_assert(fd >= 0);
-            int rc = fdin(fd, deadline);
+            dns_pollfd_result pollfd = dns_ai_pollfd(ai);
+            dill_assert(pollfd.fd >= 0);
+            int rc = (pollfd.want_events &= DNS_POLLOUT)
+                    ? fdout(pollfd.fd, deadline) : fdin(pollfd.fd, deadline);
             /* There's no guarantee that the file descriptor will be reused
                in next iteration. We have to clean the fdwait cache here
                to be on the safe side. */
             int err = errno;
-            fdclean(fd);
+            fdclean(pollfd.fd);
             errno = err;
             if(dill_slow(rc < 0)) {
                 dns_ai_close(ai);


### PR DESCRIPTION
When using non-local DNS resolver, large replies over TCP will break the existing code.

We need to be able to wait for the events to go out (`POLLOUT`), not just wait for the `POLLIN`. That's when we use a TCP fall-back.

Associated pull request to the upstream: https://github.com/wahern/dns/pull/22

You can test this patch (or breakage of existing code) by attempting to resolve:

 * large-dns-response-1k.lionet.info
 * large-dns-response-2k.lionet.info
 * large-dns-response-4k.lionet.info
 * large-dns-response-8k.lionet.info

## Steps to reproduce

 * Make sure your `/etc/resolv.conf` points to a non-local DNS resolver.
 * Attempt to `ipaddr_remote("large-dns-response-4k.lionet.info")`.