### PR TITLE
Long dns names

### DIFF
--- a/ipaddr.c
+++ b/ipaddr.c
@@ -292,8 +292,10 @@ int ipaddr_remote(struct ipaddr *addr, const char *name, int port, int mode,
         rc = dns_ai_nextent(&it, ai);
         if(rc == EAGAIN) {
             int fd = dns_ai_pollfd(ai);
+            int events = dns_ai_events(ai);
             dill_assert(fd >= 0);
-            int rc = fdin(fd, deadline);
+            int rc = (events & DNS_POLLOUT)
+                        ? fdout(fd, deadline) : fdin(fd, deadline);
             /* There's no guarantee that the file descriptor will be reused
                in next iteration. We have to clean the fdwait cache here
                to be on the safe side. */

--- a/tests/ipaddr.c
+++ b/tests/ipaddr.c
@@ -62,5 +62,19 @@ int main(void) {
     ipaddr_str(&addr, buf);
     assert(strcmp(buf, "::1") == 0);
 
+    for(int hindex = 0; hindex < 4; hindex++) {
+        static char *hostnames[] = {
+            "large-dns-response-1k.lionet.info",
+            "large-dns-response-2k.lionet.info",
+            "large-dns-response-4k.lionet.info",
+            "large-dns-response-8k.lionet.info"
+        };
+
+        rc = ipaddr_remote(&addr, hostnames[hindex], 80, 0, now() + 5000);
+        assert(rc == 0);
+        ipaddr_str(&addr, buf);
+        assert(strncmp("127.0.", buf, 6) == 0);
+    }
+
     return 0;
 }


### PR DESCRIPTION
When using non-local DNS resolver, large replies over TCP will break the existing code.

We need to be able to wait for the events to go out (POLLOUT), not just wait for the POLLIN. That's when we use a TCP fall-back.

## Steps to reproduce

Make sure your /etc/resolv.conf points to a non-local DNS resolver.
Attempt to ipaddr_remote("large-dns-response-4k.lionet.info").
