### PR TITLE
Include pthread_np.h on OpenBSD for pthread_main_np.

### DIFF
--- a/ctx.c
+++ b/ctx.c
@@ -65,7 +65,7 @@ static int dill_ismain() {
 }
 #elif defined __OpenBSD__ || defined __FreeBSD__ || \
     defined __APPLE__ || defined __DragonFly__
-#if defined __FreeBSD__
+#if defined __FreeBSD__ || defined __OpenBSD__
 #include <pthread_np.h>
 #endif
 static int dill_ismain() {


### PR DESCRIPTION
      CC       libdill_la-ctx.lo
    ctx.c:72:12: warning: implicit declaration of function 'pthread_main_np' is
          invalid in C99 [-Wimplicit-function-declaration]
        return pthread_main_np();
               ^
    1 warning generated.