### PR TITLE
fix free() logic in dill_http_hclose(), only free if malloc'd

### DIFF
--- a/http.c
+++ b/http.c
@@ -318,6 +318,6 @@ static void dill_http_hclose(struct dill_hvfs *hvfs) {
         int rc = dill_hclose(obj->u);
         dill_assert(rc == 0);
     }
-    if(obj->mem) free(obj);
+    if(!obj->mem) free(obj);
 }
 


### PR DESCRIPTION
dill_http_attach allocates memory with obj = malloc(), however the logic was reversed in dill_http_hclose such that allocated memory would not be freed (or worse still, if dill_http_attach_mem was called to attach then on dill_http_hclose free would be called referencing memory that had not been allocated).