### PR TITLE
avoid issue with memset (optimizer issue with builtin_memset?)

### DIFF
--- a/dns/dns.c
+++ b/dns/dns.c
@@ -7442,7 +7442,8 @@ static int dns_ai_setent(struct addrinfo **ent, union dns_any *any, enum dns_typ
 
 	switch (type) {
 	case DNS_T_A:
-		saddr	= memset(&sin, '\0', sizeof sin);
+		memset(&sin, '\0', sizeof sin);
+		saddr	= (struct sockaddr *)&sin;
 
 		sin.sin_family	= AF_INET;
 		sin.sin_port	= htons(ai->port);
@@ -7454,7 +7455,8 @@ static int dns_ai_setent(struct addrinfo **ent, union dns_any *any, enum dns_typ
 
 		break;
 	case DNS_T_AAAA:
-		saddr	= memset(&sin6, '\0', sizeof sin6);
+		memset(&sin6, '\0', sizeof sin6);
+		saddr	= (struct sockaddr *)&sin6;
 
 		sin6.sin6_family	= AF_INET6;
 		sin6.sin6_port		= htons(ai->port);


### PR DESCRIPTION
I've ran into a problem on Ubuntu 18 where DNS isn't working correctly. The behavior is seen as:

$ ./tutorial/sockets/step4 http libdill.org /index.html
Cannot resolve server address: Cannot assign requested address
$

I tracked this down to the following statement in dns_ai_setent()... 

saddr	= memset(&sin, '\0', sizeof sin);

what appears to be happening is that the compiler is optimizing out this statement such that saddr != &sin after this statement. The result is that dill_ipaddr_remote() is calling dns_ai_nextent() and the value returned int &it isn't the right data (because it was copied to saddr, which != &sin)

The patch replaces this one statement with two such that if the memset call is optimized away then saadr is still set to the correct address. Incidentally, compiling with "-fno-builtin-memset" also resolves the issue (If you'd rather a patch to update CFLAGS, let me know and I can submit that change instead). 
