### PR TITLE
independant busy states for TCP send/recv

### DIFF
--- a/tcp.c
+++ b/tcp.c
@@ -50,7 +50,8 @@ struct dill_tcp_conn {
     struct dill_bsock_vfs bvfs;
     int fd;
     struct dill_fd_rxbuf rxbuf;
-    unsigned int busy : 1;
+    unsigned int rbusy : 1;
+    unsigned int sbusy : 1;
     unsigned int indone : 1;
     unsigned int outdone: 1;
     unsigned int inerr : 1;
@@ -77,7 +78,8 @@ static int dill_tcp_makeconn(int fd, void *mem) {
     self->bvfs.brecvl = dill_tcp_brecvl;
     self->fd = fd;
     dill_fd_initrxbuf(&self->rxbuf);
-    self->busy = 0;
+    self->rbusy = 0;
+    self->sbusy = 0;
     self->indone = 0;
     self->outdone = 0;
     self->inerr = 0;
@@ -168,12 +170,12 @@ error1:
 static int dill_tcp_bsendl(struct dill_bsock_vfs *bvfs,
       struct dill_iolist *first, struct dill_iolist *last, int64_t deadline) {
     struct dill_tcp_conn *self = dill_cont(bvfs, struct dill_tcp_conn, bvfs);
-    if(dill_slow(self->busy)) {errno = EBUSY; return -1;}
+    if(dill_slow(self->sbusy)) {errno = EBUSY; return -1;}
     if(dill_slow(self->outdone)) {errno = EPIPE; return -1;}
     if(dill_slow(self->outerr)) {errno = ECONNRESET; return -1;}
-    self->busy = 1;
+    self->sbusy = 1;
     ssize_t sz = dill_fd_send(self->fd, first, last, deadline);
-    self->busy = 0;
+    self->sbusy = 0;
     if(dill_fast(sz >= 0)) return sz;
     self->outerr = 1;
     return -1;
@@ -182,12 +184,12 @@ static int dill_tcp_bsendl(struct dill_bsock_vfs *bvfs,
 static int dill_tcp_brecvl(struct dill_bsock_vfs *bvfs,
       struct dill_iolist *first, struct dill_iolist *last, int64_t deadline) {
     struct dill_tcp_conn *self = dill_cont(bvfs, struct dill_tcp_conn, bvfs);
-    if(dill_slow(self->busy)) {errno = EBUSY; return -1;}
+    if(dill_slow(self->rbusy)) {errno = EBUSY; return -1;}
     if(dill_slow(self->indone)) {errno = EPIPE; return -1;}
     if(dill_slow(self->inerr)) {errno = ECONNRESET; return -1;}
-    self->busy = 1;
+    self->rbusy = 1;
     int rc = dill_fd_recv(self->fd, &self->rxbuf, first, last, deadline);
-    self->busy = 0;
+    self->rbusy = 0;
     if(dill_fast(rc == 0)) return 0;
     if(errno == EPIPE) self->indone = 1;
     else self->inerr = 1;


### PR DESCRIPTION
This patch is pretty self-explanatory. It enables the TCP connection to handle reads and writes asyncronously. Reads don't block writes and writes don't block reads but reads do still block other reads and writes other writes. 
