### PR TITLE
fix --disable-sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(CMAKE_REQUIRED_LIBRARIES )
 set(CMAKE_REQUIRED_DEFINITIONS )
 
 add_definitions(-DDILL_THREADS)
+add_definitions(-DDILL_SOCKETS)
 
 check_function_exists(mprotect HAVE_MPROTECT)
 if(HAVE_MPROTECT)

--- a/configure.ac
+++ b/configure.ac
@@ -145,6 +145,7 @@ AC_ARG_ENABLE([sockets], [AS_HELP_STRING([--disable-sockets],
 if test "x$enable_sockets" = "xno"; then
     AM_CONDITIONAL([DILL_SOCKETS], false)
 else
+    AC_DEFINE(DILL_SOCKETS)
     AM_CONDITIONAL([DILL_SOCKETS], true)
 fi
 

--- a/ctx.c
+++ b/ctx.c
@@ -35,13 +35,17 @@ static void dill_ctx_init_(struct dill_ctx *ctx) {
     dill_assert(rc == 0);
     rc = dill_ctx_pollset_init(&ctx->pollset);
     dill_assert(rc == 0);
+#if defined DILL_SOCKETS
     rc = dill_ctx_fd_init(&ctx->fd);
     dill_assert(rc == 0);
+#endif
 }
 
 static void dill_ctx_term_(struct dill_ctx *ctx) {
     dill_assert(ctx->initialized == 1);
+#if defined DILL_SOCKETS
     dill_ctx_fd_term(&ctx->fd);
+#endif
     dill_ctx_pollset_term(&ctx->pollset);
     dill_ctx_stack_term(&ctx->stack);
     dill_ctx_handle_term(&ctx->handle);

--- a/ctx.h
+++ b/ctx.h
@@ -37,7 +37,9 @@ struct dill_ctx {
     struct dill_ctx_handle handle;
     struct dill_ctx_stack stack;
     struct dill_ctx_pollset pollset;
+#if defined DILL_SOCKETS
     struct dill_ctx_fd fd;
+#endif
 };
 
 struct dill_ctx *dill_ctx_init(void);

--- a/libdill.h
+++ b/libdill.h
@@ -129,7 +129,7 @@ DILL_EXPORT __attribute__((noinline)) void dill_epilogue(void);
 
 /* Stack-switching on X86-64. */
 #if defined(__x86_64__) && !defined DILL_ARCH_FALLBACK
-#define dill_setjmp(ctx) ({\
+#define dill_setjmp(ctx) __extension__ ({\
     int ret;\
     asm("lea     LJMPRET%=(%%rip), %%rcx\n\t"\
         "xor     %%rax, %%rax\n\t"\
@@ -173,7 +173,7 @@ DILL_EXPORT __attribute__((noinline)) void dill_epilogue(void);
 
 /* Stack switching on X86. */
 #elif defined(__i386__) && !defined DILL_ARCH_FALLBACK
-#define dill_setjmp(ctx) ({\
+#define dill_setjmp(ctx) __extension__ ({\
     int ret;\
     asm("movl   $LJMPRET%=, %%ecx\n\t"\
         "movl   %%ebx, (%%edx)\n\t"\
@@ -226,7 +226,7 @@ DILL_EXPORT __attribute__((noinline)) void dill_epilogue(void);
    get weird values. To avoid that, we use fancy names (dill_*__). */ 
 
 #define dill_go_(fn, ptr, len, bndl) \
-    ({\
+    __extension__ ({\
         sigjmp_buf *dill_ctx__;\
         void *dill_stk__ = (ptr);\
         int dill_handle__ = dill_prologue(&dill_ctx__, &dill_stk__, (len),\


### PR DESCRIPTION
Similar to #120, looks like `--disable-sockets` is broken since 7e663dd467.
```
alex@aineko:~/src/libdill$ ./configure --enable-debug --disable-shared --disable-sockets --disable-tls
alex@aineko:~/src/libdill$ make V=1
[snipped]
gcc -DPACKAGE_NAME=\"libdill\" -DPACKAGE_TARNAME=\"libdill\" -DPACKAGE_VERSION=\"Unknown\" -DPACKAGE_STRING=\"libdill\ Unknown\" -DPACKAGE_BUGREPORT=\"sustrik@250bpm.com\" -DPACKAGE_URL=\"http://libdill.org/\" -DPACKAGE=\"libdill\" -DVERSION=\"Unknown\" -DDILL_THREADS=1 -DDILL_PTHREAD=1 -DHAVE_POSIX_MEMALIGN=1 -DHAVE_MPROTECT=1 -DHAVE_LIBRT=1 -DHAVE_CLOCK_GETTIME=1 -DHAVE_EPOLL_CREATE=1 -DHAVE_EPOLL=1 -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -I.     -g -O2 -g -O0 -MT perf/go.o -MD -MP -MF $depbase.Tpo -c -o perf/go.o perf/go.c &&\
mv -f $depbase.Tpo $depbase.Po
/bin/bash ./libtool  --tag=CC   --mode=link gcc  -g -O2 -g -O0   -o perf/go perf/go.o libdill.la -lrt 
libtool: link: gcc -g -O2 -g -O0 -o perf/go perf/go.o  ./.libs/libdill.a -lpthread -lrt -pthread
./.libs/libdill.a(libdill_la-ctx.o): In function `dill_ctx_init_':
/home/alex/src/objmap/libdill/ctx.c:39: undefined reference to `dill_ctx_fd_init'
./.libs/libdill.a(libdill_la-ctx.o): In function `dill_ctx_term_':
/home/alex/src/objmap/libdill/ctx.c:47: undefined reference to `dill_ctx_fd_term'
collect2: error: ld returned 1 exit status
Makefile:1208: recipe for target 'perf/go' failed
make[1]: *** [perf/go] Error 1
make[1]: Leaving directory '/home/alex/src/objmap/libdill'
Makefile:1926: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
```

Compile tested, new to `libdill` so about to find out what this breaks :)