### PR TITLE
Variable initialization and apparent copy/paste error removed.

### DIFF
--- a/http.c
+++ b/http.c
@@ -109,7 +109,7 @@ int dill_http_done(int s, int64_t deadline) {
 }
 
 int dill_http_detach(int s, int64_t deadline) {
-    int err;
+    int err = 0;
     struct dill_http_sock *obj = dill_hquery(s, dill_http_type);
     if(dill_slow(!obj)) return -1;
     int u = dill_term_detach(obj->u, deadline);

--- a/iol.c
+++ b/iol.c
@@ -36,7 +36,7 @@ int dill_iolcheck(struct iolist *first, struct iolist *last,
     }
     if(dill_slow(!first || !last || last->iol_next)) {
         errno = EINVAL; return -1;}
-    size_t nbf = 0, nbt = 0, res = 0;
+    size_t nbf = 0, nbt = 0;
     struct iolist *it;
     for(it = first; it; it = it->iol_next) {
         if(dill_slow(it->iol_rsvd || (!it->iol_next && it != last)))

--- a/prefix.c
+++ b/prefix.c
@@ -86,7 +86,7 @@ int dill_prefix_attach_mem(int s, size_t hdrlen, int flags,
     self->mem = 1;
     /* Create the handle. */
     int h = dill_hmake(&self->hvfs);
-    if(dill_slow(h < 0)) {int err = errno; goto error;}
+    if(dill_slow(h < 0)) {err = errno; goto error;}
     return h;
 error:
     if(s >= 0) dill_hclose(s);

--- a/socks5.c
+++ b/socks5.c
@@ -436,7 +436,7 @@ int dill_socks5_proxy_recvcommand(int s, struct dill_ipaddr *ipaddr,
     }
     _socks5_addr s5addr;
     s5addr.atyp = conn[3];
-    uint16_t *port;
+    uint16_t *port = NULL;
     switch(s5addr.atyp) {
         case S5ADDR_IPV4:
             memcpy((void *)&(s5addr.addr), (void *)&(conn[4]), S5ADDR_IPV4_SZ);
@@ -473,7 +473,7 @@ int dill_socks5_proxy_recvcommandbyname(int s, char *host, int *port,
     if((conn[1] < DILL_SOCKS5_CONNECT) || (conn[1] > DILL_SOCKS5_UDP_ASSOCIATE)) {
         errno = EPROTO ; return -1;
     }
-    uint16_t *s5port;
+    uint16_t *s5port = NULL;
     switch(conn[3]) {
         case S5ADDR_IPV4:
             inet_ntop(AF_INET, (void *)&(conn[4]), host, 256);

--- a/term.c
+++ b/term.c
@@ -91,7 +91,7 @@ int dill_term_attach_mem(int s, const void *buf, size_t len,
     self->mem = 1;
     /* Create the handle. */
     int h = dill_hmake(&self->hvfs);
-    if(dill_slow(h < 0)) {int err = errno; goto error;}
+    if(dill_slow(h < 0)) {err = errno; goto error;}
     return h;
 error:
     if(s >= 0) dill_hclose(s);

--- a/tls.c
+++ b/tls.c
@@ -121,7 +121,7 @@ int dill_tls_attach_client_mem(int s, struct dill_tls_storage *mem,
     }
     /* Create the handle. */
     int h = dill_hmake(&self->hvfs);
-    if(dill_slow(h < 0)) {int err = errno; goto error4;}
+    if(dill_slow(h < 0)) {err = errno; goto error4;}
     return h;
 error4:
     BIO_vfree(bio);
@@ -207,7 +207,7 @@ int dill_tls_attach_server_mem(int s, const char *cert, const char *pkey,
     }
     /* Create the handle. */
     int h = dill_hmake(&self->hvfs);
-    if(dill_slow(h < 0)) {int err = errno; goto error4;}
+    if(dill_slow(h < 0)) {err = errno; goto error4;}
     return h;
 error4:
     BIO_vfree(bio);


### PR DESCRIPTION
These are minor alterations. Some variable initialization and some that appear to be copy paste errors.
I was using the Xcode build system which was complaining about these.