### PR TITLE
Make configurable stack-related values

### DIFF
--- a/libdill.h
+++ b/libdill.h
@@ -120,6 +120,16 @@ DILL_EXPORT __attribute__((noinline)) int dill_prologue(sigjmp_buf **ctx,
     void **ptr, size_t len, int bndl, const char *file, int line);
 DILL_EXPORT __attribute__((noinline)) void dill_epilogue(void);
 
+/* Sets the size of stacks allocated by libdill.
+   The value must be a multiple of 1024 and greater or equal to 8192.
+   Returns 0 upon success of -1 in case of failure (errno is set). */
+DILL_EXPORT int dill_stack_set_default_size(size_t sz);
+
+/* Sets the max number of stacks kept in cache by libdill.
+   The value must be strictly positive.
+   Returns 0 upon success of -1 in case of failure (errno is set). */
+DILL_EXPORT int dill_stack_set_cache_max(int nb);
+
 /* The following macros use alloca(sizeof(size_t)) because clang
    doesn't support alloca with size zero. */
 

--- a/man/manpages.src
+++ b/man/manpages.src
@@ -196,7 +196,7 @@ http_server_example = `
         if(rc == -1 && errno == EPIPE) break;
     }
     http_sendstatus(s, 200, "OK", -1);
-    s = http_detach(s, -1); 
+    s = http_detach(s, -1);
     tcp_close(s);
 `
 
@@ -898,7 +898,7 @@ fxs = [
 
             The size of the message requested from the channel must match the
             size of the message sent to the channel. Otherwise, both peers fail
-            with **EMSGSIZE** error. 
+            with **EMSGSIZE** error.
 
             If there's no one sending a message at the moment, the function
             blocks until someone shows up or until the deadline expires.
@@ -959,7 +959,7 @@ fxs = [
 
             The size of the message sent to the channel must match the size of
             the message requested from the channel. Otherwise, both peers fail
-            with **EMSGSIZE** error. 
+            with **EMSGSIZE** error.
 
             If there's no receiver for the message, the function blocks until
             one shows up or until the deadline expires.
@@ -1058,7 +1058,7 @@ fxs = [
         name: "fdclean",
         section: "File descriptors",
         info: "erases cached info about a file descriptor",
-      
+
         args: [
             {
                 name: "fd",
@@ -1099,7 +1099,7 @@ fxs = [
             success: "0",
             error: "-1",
         },
-      
+
         args: [
             {
                 name: "fd",
@@ -1147,7 +1147,7 @@ fxs = [
             success: "0",
             error: "-1",
         },
-      
+
         args: [
             {
                 name: "fd",
@@ -1346,7 +1346,7 @@ fxs = [
                 info: "The handle.",
             },
         ],
-    
+
         has_handle_argument: true,
 
         prologue: `
@@ -2340,7 +2340,7 @@ fxs = [
         prologue: `
             This function closes the outbound half of ICP connection.
             This will cause the peer to get **EPIPE** error after it has
-            received all the data. 
+            received all the data.
         `,
 
         has_handle_argument: true,
@@ -2629,7 +2629,7 @@ fxs = [
 
         prologue: `
             This function sends a message to a socket. It is a blocking
-            operation that unblocks only after entire message is sent. 
+            operation that unblocks only after entire message is sent.
             There is no such thing as partial send. If a problem, including
             timeout, occurs while sending the message error is returned to the
             user and the socket cannot be used for sending from that point on.
@@ -2668,7 +2668,7 @@ fxs = [
 
         prologue: `
             This function sends a message to a socket. It is a blocking
-            operation that unblocks only after entire message is sent. 
+            operation that unblocks only after entire message is sent.
             There is no such thing as partial send. If a problem, including
             timeout, occurs while sending the message error is returned to the
             user and the socket cannot be used for sending from that point on.
@@ -2970,7 +2970,7 @@ fxs = [
             This function closes the outbound half of TCP connection.
             Technically, it sends a FIN packet to the peer. This will, in turn,
             cause the peer to get **EPIPE** error after it has received all
-            the data. 
+            the data.
         `,
 
         has_handle_argument: true,
@@ -3353,7 +3353,7 @@ fxs = [
         prologue: `
             This function closes the outbound half of TLS connection. This will,
             in turn, cause the peer to get **EPIPE** error after it has received
-            all the data. 
+            all the data.
         `,
 
         has_handle_argument: true,
@@ -3778,7 +3778,7 @@ fxs = [
         prologue: `
             This function closes the outbound half of a WebSocket connection.
             This will, in turn, cause the peer to get **EPIPE** error after it
-            has received all the data. 
+            has received all the data.
         `,
 
         has_handle_argument: true,
@@ -4074,12 +4074,12 @@ fxs = [
                name: "buf",
                type: "void*",
                info: "Buffer to fill the terminal message into. If set to " +
-                     "**NULL** the message won't be returned.",           
+                     "**NULL** the message won't be returned.",
            },
            {
                name: "len",
                type: "size_t",
-               info: "Size of the buffer, in bytes.",           
+               info: "Size of the buffer, in bytes.",
            },
         ],
         protocol: ws_protocol,
@@ -4323,7 +4323,7 @@ function generate_man_page(fx, sections, mem) {
     /**************************************************************************/
     t += "# RETURN VALUE\n\n"
     if(fx.result) {
-        
+
         if(fx.result.success && fx.result.error) {
             t += "In case of success the function returns " +
                 fx.result.success + ". "

--- a/man/manpages.src
+++ b/man/manpages.src
@@ -694,6 +694,80 @@ fxs = [
         example: bundle_example,
     },
     {
+        name: "dill_stack_set_default_size",
+        section: "Coroutines",
+        info: "Set the size of the stacks allocated by libdill, when not specified by the application.",
+
+        result: {
+            type: "int",
+            success: "0",
+            error: "-1",
+        },
+
+        args: [
+            {
+                name: "value",
+                type: "size_t",
+                info: "Must be greater or equal to 8192 and a multiple of 1024.",
+            }
+        ],
+
+        allocates_handle: false,
+
+        prologue: `
+            Modify the size of the stacks allocated by libdill when it is not
+            specified by the application.
+        `,
+
+        errors: ["EINVAL"],
+
+        example: `
+            ...
+            int main(int argc, char **argv) {
+                dill_stack_set_default_size(16384);
+                ...
+            }
+            ...
+        `,
+    },
+    {
+        name: "dill_stack_set_cache_max",
+        section: "Coroutines",
+        info: "Set the number of stacks cached by libdill.",
+
+        result: {
+            type: "int",
+            success: "0",
+            error: "-1",
+        },
+
+        args: [
+            {
+                name: "sz",
+                type: "int",
+                info: "Must be greater to 1.",
+            }
+        ],
+
+        allocates_handle: false,
+
+        prologue: `
+            Modify the number of stacks cached by libdill to avoid too frequent
+            memory allocation and liberations.
+        `,
+
+        errors: ["EINVAL"],
+
+        example: `
+            ...
+            int main(int argc, char **argv) {
+                dill_stack_set_cache_max(256);
+                ...
+            }
+            ...
+        `,
+    },
+    {
         name: "chdone",
         section: "Channels",
         info: "half-closes a channel",

--- a/stack.c
+++ b/stack.c
@@ -48,6 +48,30 @@ static size_t dill_align(size_t val, size_t unit) {
     return val % unit ? val + unit - val % unit : val;
 }
 
+int dill_stack_set_default_size(size_t sz) {
+    if (sz < 8192 || (sz % 1024) != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    else {
+        dill_stack_size = sz;
+        errno = 0;
+        return 0;
+    }
+}
+
+int dill_stack_set_cache_max(int nb) {
+    if (nb <= 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    else {
+        dill_max_cached_stacks = nb;
+        errno = 0;
+        return 0;
+    }
+}
+
 /* Get memory page size. The query is done once. The value is cached. */
 static size_t dill_page_size(void) {
     static long pgsz = 0;


### PR DESCRIPTION
Allows to configure the default stack size, when it is not specified by the application.
Also allows to configure the max number of stacks kept in cache.

This patch is licensed under the terms of the MIT License.