### PR TITLE
configure.ac: fix ssl static build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -160,10 +160,13 @@ AM_CONDITIONAL([HAVE_TLS], [test "x$enable_tls" = xyes])
 
 if test "x$enable_tls" = "xyes"; then
     AC_DEFINE(HAVE_TLS)
-    AC_CHECK_LIB([ssl], [SSL_ctrl ], [],
-        AC_MSG_ERROR([libssl not found; install OpenSSL]))
-    AC_CHECK_LIB([crypto], [BIO_read], [],
-        AC_MSG_ERROR([libcrypto not found; install OpenSSL]))
+    PKG_CHECK_MODULES([SSL], [openssl],
+        [CFLAGS="$CFLAGS $SSL_CFLAGS" LIBS="$LIBS $SSL_LIBS"], [
+        AC_CHECK_LIB([ssl], [SSL_ctrl ], [],
+            AC_MSG_ERROR([libssl not found; install OpenSSL]))
+        AC_CHECK_LIB([crypto], [BIO_read], [],
+            AC_MSG_ERROR([libcrypto not found; install OpenSSL]))
+    ])
 fi
 
 ################################################################################


### PR DESCRIPTION
Retrieve openssl dependencies through pkg-config to fix the following static build failure:

```
checking for SSL_ctrl  in -lssl... no
configure: error: libssl not found; install OpenSSL
```

Fixes:
 - http://autobuild.buildroot.org/results/d3bbbdb8433f1da69304a42bc3f3d4a49ce52931

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>