### PR TITLE
Set close-on-exec flagas to avoid FD leaks to subprocesses

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -180,6 +180,7 @@ AC_CHECK_FUNCS([clock_gettime])
 AC_CHECK_LIB([socket], [socket])
 AC_CHECK_FUNCS([epoll_create], [AC_DEFINE([HAVE_EPOLL])])
 AC_CHECK_FUNCS([kqueue], [AC_DEFINE([HAVE_KQUEUE])])
+AC_CHECK_FUNCS([accept4], [AC_DEFINE([HAVE_ACCEPT4])])
 
 dnl Check if struct sockaddr contains sa_len member
 AC_CHECK_MEMBERS([struct sockaddr.sa_len], [], [], [
@@ -209,4 +210,3 @@ AC_CONFIG_MACRO_DIR([m4])
 
 AC_OUTPUT([Makefile man/Makefile libdill.pc])
 cp confdefs.h config.h
-

--- a/epoll.c.inc
+++ b/epoll.c.inc
@@ -62,7 +62,7 @@ int dill_ctx_pollset_init(struct dill_ctx_pollset *ctx) {
     /* Changelist is empty. */
     ctx->changelist = DILL_ENDLIST;
     /* Create the kernel-side pollset. */
-    ctx->efd = epoll_create(1);
+    ctx->efd = epoll_create1(EPOLL_CLOEXEC);
     if(dill_slow(ctx->efd < 0)) {err = errno; goto error2;}
     return 0;
 error2:

--- a/fd.c
+++ b/fd.c
@@ -419,8 +419,18 @@ void dill_fd_close(int s) {
 }
 
 int dill_fd_own(int s) {
+#ifdef F_DUPFD_CLOEXEC
+    int n = fcntl(s, F_DUPFD_CLOEXEC, 0);
+#else
+    int fd_flags = fcntl(s, F_GETFD);
     int n = dup(s);
+#endif
     if(dill_slow(n < 0)) return -1;
+#ifndef F_DUPFD_CLOEXEC
+    if (dill_fast(fd_flags != -1)) {
+        fcntl(n, F_SETFD, fd_flags);
+    }
+#endif
     dill_fd_close(s);
     return n;
 }


### PR DESCRIPTION
# Description

These fixes prevent file descriptor leaks in my application. There may still be other potential leak sources in functions that my application does not use.

I tried to implement `accept()` using `accept4()` if it is available since that avoids a potential race condition. Same with `fcntl(n,F_DUPFD_CLOEXEC,0)` instead of `dup()`.