### PR TITLE
remove redundant SO_REUSEADDR after accept()

### DIFF
--- a/fd.c
+++ b/fd.c
@@ -143,8 +143,15 @@ int dill_fd_accept(int s, struct sockaddr *addr, socklen_t *addrlen,
         int rc = dill_fdin(s, deadline);
         if(dill_slow(rc < 0)) return -1;
     }
-    int rc = dill_fd_unblock(as);
-    dill_assert(rc == 0);
+    /* Accepted sockets need O_NONBLOCK and SO_NOSIGPIPE. */
+    int opt = fcntl(as, F_GETFL, 0);
+    if(opt == -1) opt = 0;
+    int rc = fcntl(as, F_SETFL, opt | O_NONBLOCK);
+    if(dill_slow(rc != 0)) {close(as); return -1;}
+#ifdef SO_NOSIGPIPE
+    opt = 1;
+    setsockopt(as, SOL_SOCKET, SO_NOSIGPIPE, &opt, sizeof(opt));
+#endif
     return as;
 }
 

--- a/ipc.c
+++ b/ipc.c
@@ -463,9 +463,6 @@ int dill_ipc_accept_mem(int s, struct dill_ipc_storage *mem, int64_t deadline) {
     /* Try to get new connection in a non-blocking way. */
     int as = dill_fd_accept(lst->fd, NULL, NULL, deadline);
     if(dill_slow(as < 0)) {err = errno; goto error1;}
-    /* Set it to non-blocking mode. */
-    int rc = dill_fd_unblock(as);
-    if(dill_slow(rc < 0)) {err = errno; goto error2;}
     /* Create the handle. */
     int h = dill_ipc_makeconn(as, (struct dill_ipc_conn*)mem);
     if(dill_slow(h < 0)) {err = errno; goto error2;}

--- a/tcp.c
+++ b/tcp.c
@@ -384,9 +384,6 @@ int dill_tcp_accept_mem(int s, struct dill_ipaddr *addr,
     int as = dill_fd_accept(lst->fd, (struct sockaddr*)addr, &addrlen,
         deadline);
     if(dill_slow(as < 0)) {err = errno; goto error1;}
-    /* Set it to non-blocking mode. */
-    int rc = dill_fd_unblock(as);
-    if(dill_slow(rc < 0)) {err = errno; goto error2;}
     /* Create the handle. */
     int h = dill_tcp_makeconn(as, mem);
     if(dill_slow(h < 0)) {err = errno; goto error2;}


### PR DESCRIPTION
This patch fixes intermittent `tcp_accept` failures on macOS. `SO_REUSEADDR` on accepted sockets causes intermittent `EINVAL` on mac, so this skips the redundant calls and inlines `O_NONBLOCK` and `SO_NOSIGPIPE`.

I also attempted to fix my loud copilot settings (we'll see). So please excuse me on the last PR, I didn't expect copilot to jump in, and if it returns again on this one, I'll deal with it and excuse me again if it does... but at least it got me to add a regression test :)